### PR TITLE
Add macOS x64 + universal build targets

### DIFF
--- a/.github/workflows/build-deps-macos.yml
+++ b/.github/workflows/build-deps-macos.yml
@@ -1,0 +1,100 @@
+name: Build macOS Deps
+
+# Builds the VapourSynth/FFmpeg/Python dependency bundles for macOS.
+#
+# Both jobs run on the macos-15 (Apple Silicon) image:
+#   - arm64 builds natively.
+#   - x64 builds through Rosetta 2 with an Intel Homebrew prefix (/usr/local),
+#     because the Intel macos-13 runner was retired in December 2025. Under
+#     `arch -x86_64` the build tools, embedded Python and clang all emit x86_64.
+#     FFmpeg comes pre-built from evermeet.cx; see Scripts/download-deps-macos.sh.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Deps version (e.g., 1.3.0)'
+        required: true
+        type: string
+      release_tag:
+        description: 'Upload to this release tag (e.g., deps-v1.3.0). Leave empty to skip upload.'
+        required: false
+        type: string
+      arch:
+        description: 'Architecture to build'
+        required: false
+        type: choice
+        options:
+          - both
+          - arm64
+          - x64
+        default: both
+
+permissions:
+  contents: write
+
+jobs:
+  build-arm64:
+    if: ${{ inputs.arch == 'arm64' || inputs.arch == 'both' }}
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build dependencies (arm64, native)
+        run: ./Scripts/download-deps-macos.sh --force
+
+      - name: Package dependencies
+        run: ./Scripts/package-deps-macos.sh --version "${{ inputs.version }}" --arch arm64
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: VapourBox-deps-${{ inputs.version }}-macos-arm64
+          path: dist/VapourBox-deps-${{ inputs.version }}-macos-arm64.zip
+
+      - name: Upload to release
+        if: inputs.release_tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ inputs.release_tag }}" \
+            "dist/VapourBox-deps-${{ inputs.version }}-macos-arm64.zip" --clobber
+
+  build-x64:
+    if: ${{ inputs.arch == 'x64' || inputs.arch == 'both' }}
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rosetta 2
+        run: softwareupdate --install-rosetta --agree-to-license
+
+      - name: Install Intel Homebrew (/usr/local) under Rosetta
+        run: |
+          # Install the x86_64 Homebrew prefix so brew-provided libraries
+          # (zimg, fftw, boost, libdvdread, ...) are Intel binaries.
+          arch -x86_64 /bin/bash -c \
+            "NONINTERACTIVE=1 $(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          /usr/local/bin/brew --version
+
+      - name: Build dependencies (x64, via Rosetta)
+        run: |
+          # Run the whole build translated as x86_64 with Intel Homebrew first
+          # in PATH. uname -m then reports x86_64, so the script targets macos-x64.
+          arch -x86_64 /bin/bash -lc \
+            'PATH=/usr/local/bin:$PATH ./Scripts/download-deps-macos.sh --force'
+
+      - name: Package dependencies
+        run: ./Scripts/package-deps-macos.sh --version "${{ inputs.version }}" --arch x64
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: VapourBox-deps-${{ inputs.version }}-macos-x64
+          path: dist/VapourBox-deps-${{ inputs.version }}-macos-x64.zip
+
+      - name: Upload to release
+        if: inputs.release_tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ inputs.release_tag }}" \
+            "dist/VapourBox-deps-${{ inputs.version }}-macos-x64.zip" --clobber

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -12,20 +12,53 @@ on:
         required: true
         type: string
       arch:
-        description: 'Architecture'
+        description: 'Architecture (universal = one fat arm64+x86_64 DMG; both = two separate DMGs)'
         required: false
         type: choice
         options:
+          - universal
+          - both
           - arm64
-        default: arm64
+          - x64
+        default: universal
 
 jobs:
+  # Expand the arch choice into a matrix the build job fans out over.
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - id: set
+        run: |
+          case "${{ inputs.arch }}" in
+            universal) echo 'matrix=["universal"]' >> "$GITHUB_OUTPUT" ;;
+            arm64)     echo 'matrix=["arm64"]'     >> "$GITHUB_OUTPUT" ;;
+            x64)       echo 'matrix=["x64"]'       >> "$GITHUB_OUTPUT" ;;
+            both)      echo 'matrix=["arm64","x64"]' >> "$GITHUB_OUTPUT" ;;
+            *)         echo 'matrix=["universal"]' >> "$GITHUB_OUTPUT" ;;
+          esac
+
   build:
-    runs-on: macos-15  # M1 runner for arm64 support, Xcode 16+
+    needs: setup
+    runs-on: macos-15  # Apple Silicon; x64 cross-compiles via ARCHS=x86_64
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ${{ fromJSON(needs.setup.outputs.matrix) }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Resolve arch variables
+        id: arch
+        run: |
+          case "${{ matrix.arch }}" in
+            arm64)     echo "xcode_archs=arm64" >> "$GITHUB_OUTPUT" ;;
+            x64)       echo "xcode_archs=x86_64" >> "$GITHUB_OUTPUT" ;;
+            universal) echo "xcode_archs=arm64 x86_64" >> "$GITHUB_OUTPUT" ;;
+          esac
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -47,41 +80,29 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             worker/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ matrix.arch }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
+            ${{ runner.os }}-cargo-${{ matrix.arch }}-
             ${{ runner.os }}-cargo-
 
-      - name: Download macOS dependencies
+      # Per-arch deps are downloaded at runtime by the app (not bundled), so this
+      # only runs for single-arch builds to validate the matching zip exists.
+      # Universal apps download the arch-appropriate deps on first run.
+      - name: Download macOS dependencies (${{ matrix.arch }})
+        if: ${{ matrix.arch != 'universal' }}
         run: |
           DEPS_VERSION="${{ inputs.deps_tag }}"
           DEPS_VERSION="${DEPS_VERSION#deps-v}"
 
-          mkdir -p deps/macos-arm64 deps/macos-x64
-
-          # Download arm64 deps (zip contains flat structure, no wrapper folder)
-          if [[ "${{ inputs.arch }}" == "arm64" || "${{ inputs.arch }}" == "both" ]]; then
-            DEPS_URL="https://github.com/${{ github.repository }}/releases/download/${{ inputs.deps_tag }}/VapourBox-deps-${DEPS_VERSION}-macos-arm64.zip"
-            echo "Downloading arm64 deps from: $DEPS_URL"
-            curl -L -o deps-arm64.zip "$DEPS_URL"
-            unzip -o deps-arm64.zip -d deps/macos-arm64
-            rm -f deps-arm64.zip
-          fi
-
-          # Download x64 deps (zip contains flat structure, no wrapper folder)
-          if [[ "${{ inputs.arch }}" == "x64" || "${{ inputs.arch }}" == "both" ]]; then
-            DEPS_URL="https://github.com/${{ github.repository }}/releases/download/${{ inputs.deps_tag }}/VapourBox-deps-${DEPS_VERSION}-macos-x64.zip"
-            echo "Downloading x64 deps from: $DEPS_URL"
-            curl -L -o deps-x64.zip "$DEPS_URL"
-            unzip -o deps-x64.zip -d deps/macos-x64
-            rm -f deps-x64.zip
-          fi
-
-          echo "Dependencies extracted:"
-          ls -la deps/
+          mkdir -p deps/macos-${{ matrix.arch }}
+          DEPS_URL="https://github.com/${{ github.repository }}/releases/download/${{ inputs.deps_tag }}/VapourBox-deps-${DEPS_VERSION}-macos-${{ matrix.arch }}.zip"
+          echo "Downloading ${{ matrix.arch }} deps from: $DEPS_URL"
+          curl -L -o deps.zip "$DEPS_URL"
+          unzip -o deps.zip -d deps/macos-${{ matrix.arch }}
+          rm -f deps.zip
 
       - name: Setup CocoaPods
-        run: |
-          gem install cocoapods
+        run: gem install cocoapods
 
       - name: Update version numbers
         run: |
@@ -103,19 +124,28 @@ jobs:
           # Update Cargo.toml
           sed -i '' "s/^version = \".*\"/version = \"${VERSION}\"/" worker/Cargo.toml
 
-      - name: Build Rust worker (arm64)
-        if: ${{ inputs.arch == 'arm64' || inputs.arch == 'both' }}
+      - name: Build Rust worker (${{ matrix.arch }})
         run: |
           cd worker
-          cargo build --release --target aarch64-apple-darwin
+          case "${{ matrix.arch }}" in
+            arm64)
+              cargo build --release --target aarch64-apple-darwin ;;
+            x64)
+              cargo build --release --target x86_64-apple-darwin ;;
+            universal)
+              cargo build --release --target aarch64-apple-darwin
+              cargo build --release --target x86_64-apple-darwin
+              mkdir -p target/universal/release
+              lipo -create -output target/universal/release/vapourbox-worker \
+                target/aarch64-apple-darwin/release/vapourbox-worker \
+                target/x86_64-apple-darwin/release/vapourbox-worker
+              lipo -info target/universal/release/vapourbox-worker ;;
+          esac
 
-      - name: Build Rust worker (x64)
-        if: ${{ inputs.arch == 'x64' || inputs.arch == 'both' }}
-        run: |
-          cd worker
-          cargo build --release --target x86_64-apple-darwin
-
-      - name: Build Flutter app
+      - name: Build Flutter app (${{ matrix.arch }})
+        env:
+          # Drives app/macos/Podfile to build Pods for the target arch.
+          VAPOURBOX_ARCHS: ${{ steps.arch.outputs.xcode_archs }}
         run: |
           cd app
           flutter pub get
@@ -130,14 +160,17 @@ jobs:
           rm -rf Pods Podfile.lock
           pod install
 
-          # Build Pods-Runner scheme first (all CocoaPods dependencies)
+          # Build Pods-Runner scheme first (all CocoaPods dependencies).
+          # ARCHS is quoted so the universal value "arm64 x86_64" stays one arg.
           xcodebuild -workspace Runner.xcworkspace -scheme Pods-Runner \
               -configuration Release build ONLY_ACTIVE_ARCH=NO \
+              ARCHS="${{ steps.arch.outputs.xcode_archs }}" \
               -quiet
 
-          # Build Runner for arm64 only (must match Podfile ARCHS setting)
+          # Build Runner for the target arch (must match Podfile ARCHS setting)
           xcodebuild -workspace Runner.xcworkspace -scheme Runner \
-              -configuration Release build ARCHS=arm64 ONLY_ACTIVE_ARCH=YES \
+              -configuration Release build ONLY_ACTIVE_ARCH=NO \
+              ARCHS="${{ steps.arch.outputs.xcode_archs }}" \
               -quiet
 
           # Copy to Flutter build location
@@ -183,32 +216,21 @@ jobs:
           echo "Signing identities available:"
           security find-identity -v -p codesigning "$KEYCHAIN_PATH"
 
-      - name: Package release (arm64)
-        if: ${{ inputs.arch == 'arm64' || inputs.arch == 'both' }}
+      - name: Package release (${{ matrix.arch }})
         env:
           NOTARY_APPLE_ID: ${{ secrets.MACOS_NOTARY_APPLE_ID }}
           NOTARY_PASSWORD: ${{ secrets.MACOS_NOTARY_PASSWORD }}
           NOTARY_TEAM_ID: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
         run: |
-          ./Scripts/package-macos.sh --version "${{ inputs.version }}" --arch arm64 --skip-build --notarize
-
-      - name: Package release (x64)
-        if: ${{ inputs.arch == 'x64' || inputs.arch == 'both' }}
-        env:
-          NOTARY_APPLE_ID: ${{ secrets.MACOS_NOTARY_APPLE_ID }}
-          NOTARY_PASSWORD: ${{ secrets.MACOS_NOTARY_PASSWORD }}
-          NOTARY_TEAM_ID: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
-        run: |
-          ./Scripts/package-macos.sh --version "${{ inputs.version }}" --arch x64 --skip-build --notarize
+          ./Scripts/package-macos.sh --version "${{ inputs.version }}" --arch ${{ matrix.arch }} --skip-build --notarize
 
       - name: Clean up signing keychain
         if: always()
         run: |
           security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db" 2>/dev/null || true
 
-      - name: Upload artifacts
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: VapourBox-${{ inputs.version }}-macos
-          path: dist/VapourBox-${{ inputs.version }}-macos-*.dmg
-
+          name: VapourBox-${{ inputs.version }}-macos-${{ matrix.arch }}
+          path: dist/VapourBox-${{ inputs.version }}-macos-${{ matrix.arch }}.dmg

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,12 +113,23 @@ VapourBox/
 ### Download Dependencies
 
 ```bash
-# macOS
+# macOS arm64 (native)
 ./scripts/download-deps-macos.sh
+
+# macOS x64 — built on Apple Silicon via Rosetta 2 + Intel Homebrew (macos-13
+# Intel runner was retired Dec 2025). uname -m reports x86_64 under Rosetta, so
+# the script targets deps/macos-x64. FFmpeg comes pre-built from evermeet.cx;
+# tmedian/bestsource from Stefan-Olt; the rest build from source.
+softwareupdate --install-rosetta --agree-to-license
+arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"  # Intel brew at /usr/local
+arch -x86_64 /bin/bash -lc 'PATH=/usr/local/bin:$PATH ./Scripts/download-deps-macos.sh --force'
 
 # Windows (PowerShell)
 .\scripts\download-deps-windows.ps1
 ```
+
+Both macOS architectures are produced in CI by `build-deps-macos.yml` (arm64 job
+native on `macos-15`; x64 job runs the same script under Rosetta).
 
 ### Build Rust Worker
 
@@ -424,12 +435,15 @@ The `download-deps-windows.ps1` and `download-deps-macos.sh` scripts apply these
 
 ### macOS
 
-- Fully self-contained deps (no Homebrew): Python 3.12 (python-build-standalone), VS built from source
+- Two arches: `deps/macos-arm64` (native build) and `deps/macos-x64` (built via Rosetta 2 — see Download Dependencies). The Flutter `DependencyLocator` and Rust runtime pick the arch at runtime via `uname`.
+- Fully self-contained deps (no Homebrew at runtime): Python 3.12 (python-build-standalone), VS built from source
 - Worker sets: `PYTHONHOME`, `PYTHONPATH`, `VAPOURSYNTH_CONF_PATH`, `DYLD_LIBRARY_PATH`
 - `vspipe` is a wrapper script that generates config dynamically (needed because `VAPOURSYNTH_PLUGIN_PATH` is additive, not a replacement)
+- **x64 FFmpeg** is sourced pre-built from evermeet.cx (static x86_64, links only system frameworks); arm64 FFmpeg comes from Homebrew. **x64 plugins** build from source under Rosetta, except `tmedian`/`bestsource` which come pre-built from Stefan-Olt/vs-plugin-build.
 - **Code signing**: After `install_name_tool` modifications, binaries must be re-signed: `codesign -s - -f <binary>` (exit code 137 = SIGKILL means invalid signature)
 - Quarantine removal: `xattr -cr` on deps after download
 - Show in Folder: `open -R <path>`
+- **Apple Silicon app build for x64**: the `app/macos/Podfile` reads `VAPOURBOX_ARCHS` (default `arm64`); set it to `x86_64` and pass `ARCHS=x86_64` to xcodebuild to cross-compile the Intel Runner.
 
 Plugin lists for both platforms: see `deps/` directories or download scripts.
 
@@ -529,6 +543,10 @@ Create the app-specific password at appleid.apple.com → Sign-In and Security �
 - Flutter Windows can't build on macOS — use GitHub Actions
 - Windows deps can be zipped on macOS if `deps/windows-x64/` exists
 - The macOS CI build (`build-macos.yml`) signs with the Developer ID cert and notarizes — see "macOS Code Signing & Notarization" below. Windows CI builds remain unsigned.
+- macOS ships as a **universal** (arm64+x86_64) app by default. `build-macos.yml` takes an `arch` input (`universal` | `both` | `arm64` | `x64`, default `universal`) and fans out via a matrix. Universal = lipo'd worker + Runner built with `ARCHS="arm64 x86_64"`; `both` = two separate single-arch DMGs. The x64 slice cross-compiles on the `macos-15` (arm64) runner.
+- Deps are **not** bundled — the app downloads `macos-arm64` or `macos-x64` deps at runtime per `uname`, so a universal app needs **both** deps bundles published. macOS deps are built by `build-deps-macos.yml` (x64 via Rosetta 2 — the Intel `macos-13` runner was retired Dec 2025).
+- `app/macos/Podfile` reads `VAPOURBOX_ARCHS` (default `arm64`; set to `x86_64` or `arm64 x86_64`); `package-macos.sh --arch universal` sets this and lipo's the worker.
+- After publishing a new x64 deps zip, fill in `app/assets/deps-version.json` → `macos-x64.sha256`/`.size` (printed by `package-deps-macos.sh`); both platforms must be non-null before release.
 
 ### Dependency Version History
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ Get the latest release for your platform:
 
 | Platform | File |
 |----------|------|
-| macOS (Apple Silicon) | `VapourBox-x.x.x-macos-arm64.dmg` |
+| macOS (Universal — Apple Silicon & Intel) | `VapourBox-x.x.x-macos-universal.dmg` |
 | Windows 10/11 (x64) | `VapourBox-x.x.x-windows-x64.zip` |
+
+> The macOS DMG is a universal binary that runs natively on both Apple Silicon and Intel Macs; the correct processing dependencies are downloaded for your CPU on first launch.
 
 ## Installation
 
@@ -169,6 +171,7 @@ Stuart Cameron - [stuart-cameron.com](https://stuart-cameron.com)
 
 ### Pre-built Binary Sources
 
-macOS ARM64 plugins sourced from:
+macOS plugins and binaries sourced from:
 - **[yuygfgg/Macos_vapoursynth_plugins](https://github.com/yuygfgg/Macos_vapoursynth_plugins)** — pre-built ARM64 VapourSynth plugins for macOS
-- **[Stefan-Olt/vs-plugin-build](https://github.com/Stefan-Olt/vs-plugin-build)** — Cross-platform VapourSynth plugins
+- **[Stefan-Olt/vs-plugin-build](https://github.com/Stefan-Olt/vs-plugin-build)** — cross-platform VapourSynth plugins (arm64 + x86_64; used for `tmedian` and `bestsource`)
+- **[evermeet.cx](https://evermeet.cx/ffmpeg/)** — static x86_64 FFmpeg/FFprobe builds for the Intel macOS bundle

--- a/Scripts/ci-build-and-release.sh
+++ b/Scripts/ci-build-and-release.sh
@@ -10,7 +10,7 @@
 # Options:
 #   --version X.Y.Z       App version (required)
 #   --deps-tag TAG        Deps release tag (default: from deps-version.json)
-#   --arch ARCH           macOS arch: arm64, x64, both (default: arm64)
+#   --arch ARCH           macOS arch: universal, both, arm64, x64 (default: universal)
 #   --skip-trigger        Skip triggering workflows (just download + upload)
 
 set -e
@@ -26,7 +26,7 @@ NC='\033[0m'
 
 VERSION=""
 DEPS_TAG=""
-ARCH="arm64"
+ARCH="universal"
 SKIP_TRIGGER=false
 
 while [[ $# -gt 0 ]]; do
@@ -36,7 +36,7 @@ while [[ $# -gt 0 ]]; do
         --arch) ARCH="$2"; shift 2 ;;
         --skip-trigger) SKIP_TRIGGER=true; shift ;;
         -h|--help)
-            echo "Usage: $0 --version X.Y.Z [--deps-tag TAG] [--arch arm64|x64|both] [--skip-trigger]"
+            echo "Usage: $0 --version X.Y.Z [--deps-tag TAG] [--arch universal|both|arm64|x64] [--skip-trigger]"
             exit 0
             ;;
         *) echo "Unknown option: $1"; exit 1 ;;

--- a/Scripts/download-deps-macos.sh
+++ b/Scripts/download-deps-macos.sh
@@ -43,6 +43,13 @@ else
     exit 1
 fi
 
+# NOTE: To build x64 deps on an Apple Silicon Mac (or the macos-15 arm64 CI
+# runner), run this script translated through Rosetta 2 with an Intel Homebrew
+# prefix first in PATH, e.g.:
+#   arch -x86_64 /bin/bash -lc 'PATH=/usr/local/bin:$PATH ./Scripts/download-deps-macos.sh --force'
+# Under Rosetta `uname -m` reports x86_64, so $ARCH/$PLATFORM_DIR and every build
+# tool (brew, meson, ninja, clang, embedded python) emit x86_64.
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 DEPS_DIR="$PROJECT_ROOT/deps/$PLATFORM_DIR"
@@ -81,7 +88,12 @@ BREW_DEPS=(
     cmake meson ninja nasm autoconf automake libtool pkg-config cython
     # Libraries needed to build (will be copied, not linked at runtime from homebrew)
     zimg
-    # FFmpeg (will be copied)
+    # Support libraries bundled into deps/.../lib (copied, not linked from homebrew):
+    #   fftw       -> libfftw3f.3 + libfftw3f_threads.3 (dfttest)
+    #   boost      -> libboost_filesystem + libboost_atomic (nnedi3cl)
+    #   libdvdread -> libdvdread (DVD title extraction in the worker)
+    fftw boost libdvdread
+    # FFmpeg (arm64 copies this; x64 uses evermeet.cx static builds instead)
     ffmpeg
 )
 
@@ -306,14 +318,29 @@ else
 fi
 
 # ============================================================================
-# Copy FFmpeg
+# FFmpeg
 # ============================================================================
 echo ""
-echo "=== Copying FFmpeg ==="
-cp "$BREW_PREFIX/bin/ffmpeg" "$DEPS_DIR/ffmpeg/"
-cp "$BREW_PREFIX/bin/ffprobe" "$DEPS_DIR/ffmpeg/"
-chmod +x "$DEPS_DIR/ffmpeg/ffmpeg" "$DEPS_DIR/ffmpeg/ffprobe"
-echo "  Copied FFmpeg"
+echo "=== Installing FFmpeg ==="
+if [ "$ARCH" = "x86_64" ]; then
+    # evermeet.cx ships static x86_64 ffmpeg/ffprobe that link only system
+    # frameworks (verified self-contained), so no dylib wrangling is needed.
+    # This is the canonical pre-built source for Intel macOS ffmpeg.
+    echo "  Downloading static x86_64 FFmpeg from evermeet.cx..."
+    curl -sL "https://evermeet.cx/ffmpeg/getrelease/ffmpeg/zip" -o "$BUILD_DIR/ffmpeg.zip"
+    curl -sL "https://evermeet.cx/ffmpeg/getrelease/ffprobe/zip" -o "$BUILD_DIR/ffprobe.zip"
+    unzip -q -o "$BUILD_DIR/ffmpeg.zip" -d "$DEPS_DIR/ffmpeg/"
+    unzip -q -o "$BUILD_DIR/ffprobe.zip" -d "$DEPS_DIR/ffmpeg/"
+    chmod +x "$DEPS_DIR/ffmpeg/ffmpeg" "$DEPS_DIR/ffmpeg/ffprobe"
+    codesign -s - -f "$DEPS_DIR/ffmpeg/ffmpeg" 2>/dev/null || true
+    codesign -s - -f "$DEPS_DIR/ffmpeg/ffprobe" 2>/dev/null || true
+    echo "  Installed evermeet.cx FFmpeg"
+else
+    cp "$BREW_PREFIX/bin/ffmpeg" "$DEPS_DIR/ffmpeg/"
+    cp "$BREW_PREFIX/bin/ffprobe" "$DEPS_DIR/ffmpeg/"
+    chmod +x "$DEPS_DIR/ffmpeg/ffmpeg" "$DEPS_DIR/ffmpeg/ffprobe"
+    echo "  Copied FFmpeg from Homebrew"
+fi
 
 # ============================================================================
 # Download pre-built plugins from yuygfgg/Macos_vapoursynth_plugins (ARM64)
@@ -370,6 +397,40 @@ if [ "$ARCH" = "arm64" ]; then
     codesign -s - -f "$PLUGINS_DIR/libvivtc.dylib" 2>/dev/null
 
     echo "  Downloaded pre-built ARM64 plugins from yuygfgg"
+else
+    # x86_64: no yuygfgg equivalent. Source the support libraries from the
+    # (Intel) Homebrew prefix; neo-f3kdb / dfttest / vivtc are built from source
+    # below (see the "$ARCH" != "arm64" branches).
+    echo "  Sourcing x86_64 support libraries from Homebrew ($BREW_PREFIX)..."
+
+    # FFTW (required for dfttest, which is built from source on x86_64)
+    cp "$BREW_PREFIX/lib/libfftw3f.3.dylib" "$LIB_DIR/libfftw3f.3.dylib"
+    cp "$BREW_PREFIX/lib/libfftw3f_threads.3.dylib" "$LIB_DIR/libfftw3f_threads.3.dylib"
+    install_name_tool -id "@loader_path/libfftw3f.3.dylib" "$LIB_DIR/libfftw3f.3.dylib"
+    install_name_tool -id "@loader_path/libfftw3f_threads.3.dylib" "$LIB_DIR/libfftw3f_threads.3.dylib"
+    install_name_tool -change "$BREW_PREFIX/opt/fftw/lib/libfftw3f.3.dylib" "@loader_path/libfftw3f.3.dylib" "$LIB_DIR/libfftw3f_threads.3.dylib" 2>/dev/null || true
+    codesign -s - -f "$LIB_DIR/libfftw3f.3.dylib" 2>/dev/null
+    codesign -s - -f "$LIB_DIR/libfftw3f_threads.3.dylib" 2>/dev/null
+
+    # Boost (required by NNEDI3CL)
+    cp "$BREW_PREFIX/lib/libboost_filesystem.dylib" "$LIB_DIR/"
+    cp "$BREW_PREFIX/lib/libboost_atomic.dylib" "$LIB_DIR/"
+    install_name_tool -id "@loader_path/libboost_filesystem.dylib" "$LIB_DIR/libboost_filesystem.dylib"
+    install_name_tool -id "@loader_path/libboost_atomic.dylib" "$LIB_DIR/libboost_atomic.dylib"
+    install_name_tool -change "$BREW_PREFIX/opt/boost/lib/libboost_atomic.dylib" "@loader_path/libboost_atomic.dylib" "$LIB_DIR/libboost_filesystem.dylib" 2>/dev/null || true
+    codesign -s - -f "$LIB_DIR/libboost_filesystem.dylib" 2>/dev/null
+    codesign -s - -f "$LIB_DIR/libboost_atomic.dylib" 2>/dev/null
+
+    echo "  Sourced x86_64 support libraries"
+fi
+
+# libdvdread (DVD title extraction in the worker) - sourced from Homebrew for
+# both architectures. The worker dynamically loads it from deps/.../lib.
+if [ ! -f "$LIB_DIR/libdvdread.dylib" ] && [ -f "$BREW_PREFIX/lib/libdvdread.dylib" ]; then
+    echo "  Copying libdvdread..."
+    cp "$BREW_PREFIX/lib/libdvdread.dylib" "$LIB_DIR/libdvdread.dylib"
+    install_name_tool -id "@loader_path/libdvdread.dylib" "$LIB_DIR/libdvdread.dylib" 2>/dev/null || true
+    codesign -s - -f "$LIB_DIR/libdvdread.dylib" 2>/dev/null
 fi
 
 # ============================================================================
@@ -608,6 +669,94 @@ build_plugin "knlmeanscl" \
     "https://github.com/Khanattila/KNLMeansCL.git" \
     "libknlmeanscl.dylib" \
     "meson setup build --buildtype=release && ninja -C build"
+
+# DeScratch (vertical scratch removal - core.descratch.DeScratch)
+# Built from source: not available pre-built from Stefan-Olt. The repo carries
+# the VapourSynth headers as a submodule, so a recursive clone is required.
+echo ""
+echo "=== Building DeScratch ==="
+if [ "$FORCE" = true ] || [ ! -f "$PLUGINS_DIR/libdescratch.dylib" ]; then
+    rm -rf descratch
+    if git clone --depth 1 --recurse-submodules --shallow-submodules \
+        https://github.com/vapoursynth/descratch.git descratch; then
+        cd descratch
+        if meson setup build --buildtype=release && ninja -C build; then
+            lib_path=$(find build -name "*.dylib" -type f 2>/dev/null | head -1)
+            if [ -n "$lib_path" ]; then
+                cp "$lib_path" "$PLUGINS_DIR/libdescratch.dylib"
+                install_name_tool -id "@loader_path/libdescratch.dylib" "$PLUGINS_DIR/libdescratch.dylib" 2>/dev/null || true
+                echo "  Built DeScratch"
+            else
+                echo "  Warning: No .dylib found for DeScratch"
+                FAILED_PLUGINS+=("descratch")
+            fi
+        else
+            echo "  Failed to build DeScratch"
+            FAILED_PLUGINS+=("descratch")
+        fi
+        cd "$BUILD_DIR"
+    else
+        echo "  Failed to clone DeScratch"
+        FAILED_PLUGINS+=("descratch")
+    fi
+else
+    echo "  DeScratch already exists, skipping"
+fi
+
+# ============================================================================
+# Pre-built plugins from Stefan-Olt/vs-plugin-build (both architectures)
+# These are not built from source here; Stefan-Olt ships self-contained
+# darwin-aarch64 and darwin-x86_64 dylibs. Release assets are immutable, so the
+# pinned URLs below are stable - bump the version/timestamp to update.
+# ============================================================================
+echo ""
+echo "=== Downloading pre-built plugins (Stefan-Olt/vs-plugin-build) ==="
+
+download_prebuilt_plugin() {
+    local label="$1"
+    local out_name="$2"
+    local url="$3"
+
+    if [ "$FORCE" = false ] && [ -f "$PLUGINS_DIR/$out_name" ]; then
+        echo "  $label already exists, skipping"
+        return 0
+    fi
+
+    local tmp="$BUILD_DIR/prebuilt-$out_name"
+    rm -rf "$tmp"; mkdir -p "$tmp"
+    if curl -sL "$url" -o "$tmp/plugin.zip" && unzip -q -o "$tmp/plugin.zip" -d "$tmp"; then
+        local found
+        found=$(find "$tmp" -name "*.dylib" -type f 2>/dev/null | head -1)
+        if [ -n "$found" ]; then
+            cp "$found" "$PLUGINS_DIR/$out_name"
+            install_name_tool -id "@loader_path/$out_name" "$PLUGINS_DIR/$out_name" 2>/dev/null || true
+            codesign -s - -f "$PLUGINS_DIR/$out_name" 2>/dev/null || true
+            echo "  Downloaded pre-built $label"
+            return 0
+        fi
+    fi
+    echo "  Warning: failed to fetch pre-built $label"
+    FAILED_PLUGINS+=("$label")
+    return 1
+}
+
+STEFANOLT="https://github.com/Stefan-Olt/vs-plugin-build/releases/download/vsplugin"
+
+# TemporalMedian (core.tmedian.TemporalMedian - used by SpotLess)
+if [ "$ARCH" = "arm64" ]; then
+    TMEDIAN_URL="$STEFANOLT/com.nodame.temporalmedian/v1/darwin-aarch64/2024-09-30T20.56.40%2B00.00Z/TemporalMedian-v1-darwin-aarch64.zip"
+else
+    TMEDIAN_URL="$STEFANOLT/com.nodame.temporalmedian/v1/darwin-x86_64/2024-09-30T21.01.26%2B00.00Z/TemporalMedian-v1-darwin-x86_64.zip"
+fi
+download_prebuilt_plugin "TemporalMedian" "libtmedian.dylib" "$TMEDIAN_URL"
+
+# BestSource (core.bs - source loader, bundled for parity)
+if [ "$ARCH" = "arm64" ]; then
+    BESTSOURCE_URL="$STEFANOLT/com.vapoursynth.bestsource/R16/darwin-aarch64/2026-01-10T18.55.40%2B00.00Z/BestSource-R16-darwin-aarch64.zip"
+else
+    BESTSOURCE_URL="$STEFANOLT/com.vapoursynth.bestsource/R16/darwin-x86_64/2026-01-10T19.07.30%2B00.00Z/BestSource-R16-darwin-x86_64.zip"
+fi
+download_prebuilt_plugin "BestSource" "libbestsource.dylib" "$BESTSOURCE_URL"
 
 # ============================================================================
 # Download NNEDI3 weights

--- a/Scripts/package-macos.sh
+++ b/Scripts/package-macos.sh
@@ -13,7 +13,8 @@
 #
 # Options:
 #   --version X.Y.Z          Set version number (default: 1.0.0)
-#   --arch arm64|x64          Target architecture (default: auto-detect)
+#   --arch arm64|x64|universal  Target architecture (default: auto-detect host;
+#                               'universal' builds a fat arm64+x86_64 bundle)
 #   --skip-build              Skip Flutter and Rust compilation
 #   --team-id ID              Apple Developer Team ID (default: PMXZ63S6YG)
 #   --notarize                Submit to Apple notary service after signing
@@ -116,15 +117,24 @@ fi
 # Build Rust worker
 STEP=1
 if [ "$SKIP_BUILD" = false ]; then
-    echo "[$STEP/$TOTAL_STEPS] Building Rust worker..."
+    echo "[$STEP/$TOTAL_STEPS] Building Rust worker ($ARCH)..."
     cd "$PROJECT_ROOT/worker"
-    if [ "$ARCH" = "arm64" ]; then
-        cargo build --release --target aarch64-apple-darwin
-        WORKER_BIN="$PROJECT_ROOT/worker/target/aarch64-apple-darwin/release/vapourbox-worker"
-    else
-        cargo build --release --target x86_64-apple-darwin
-        WORKER_BIN="$PROJECT_ROOT/worker/target/x86_64-apple-darwin/release/vapourbox-worker"
-    fi
+    ARM_WORKER="$PROJECT_ROOT/worker/target/aarch64-apple-darwin/release/vapourbox-worker"
+    X64_WORKER="$PROJECT_ROOT/worker/target/x86_64-apple-darwin/release/vapourbox-worker"
+    case "$ARCH" in
+        arm64)
+            cargo build --release --target aarch64-apple-darwin
+            WORKER_BIN="$ARM_WORKER" ;;
+        x64)
+            cargo build --release --target x86_64-apple-darwin
+            WORKER_BIN="$X64_WORKER" ;;
+        universal)
+            cargo build --release --target aarch64-apple-darwin
+            cargo build --release --target x86_64-apple-darwin
+            mkdir -p "$PROJECT_ROOT/worker/target/universal/release"
+            WORKER_BIN="$PROJECT_ROOT/worker/target/universal/release/vapourbox-worker"
+            lipo -create -output "$WORKER_BIN" "$ARM_WORKER" "$X64_WORKER" ;;
+    esac
     # Fallback to default target if specific target not found
     if [ ! -f "$WORKER_BIN" ]; then
         cargo build --release
@@ -134,7 +144,16 @@ if [ "$SKIP_BUILD" = false ]; then
 
     # Build Flutter app (two-step xcodebuild — flutter build macos fails with module dependency errors)
     STEP=$((STEP + 1))
-    echo "[$STEP/$TOTAL_STEPS] Building Flutter app..."
+    echo "[$STEP/$TOTAL_STEPS] Building Flutter app ($ARCH)..."
+
+    # Map target arch to the Xcode ARCHS value (drives the Podfile too).
+    case "$ARCH" in
+        arm64)     XCODE_ARCHS="arm64" ;;
+        x64)       XCODE_ARCHS="x86_64" ;;
+        universal) XCODE_ARCHS="arm64 x86_64" ;;
+    esac
+    export VAPOURBOX_ARCHS="$XCODE_ARCHS"
+
     cd "$PROJECT_ROOT/app"
     flutter pub get
 
@@ -148,12 +167,14 @@ if [ "$SKIP_BUILD" = false ]; then
     echo "    Building Pods-Runner scheme..."
     xcodebuild -workspace Runner.xcworkspace -scheme Pods-Runner \
         -configuration Release build ONLY_ACTIVE_ARCH=NO \
+        ARCHS="$XCODE_ARCHS" \
         -quiet
 
-    # Step 2: Build Runner for arm64 only (must match Podfile ARCHS setting)
-    echo "    Building Runner scheme (arm64)..."
+    # Step 2: Build Runner for the target arch (must match Podfile ARCHS setting)
+    echo "    Building Runner scheme ($XCODE_ARCHS)..."
     xcodebuild -workspace Runner.xcworkspace -scheme Runner \
-        -configuration Release build ARCHS=arm64 ONLY_ACTIVE_ARCH=YES \
+        -configuration Release build ONLY_ACTIVE_ARCH=NO \
+        ARCHS="$XCODE_ARCHS" \
         -quiet
 
     # Copy to Flutter build location
@@ -170,11 +191,14 @@ else
     echo "[$STEP/$TOTAL_STEPS] Skipping Rust build (--skip-build)"
     STEP=$((STEP + 1))
     echo "[$STEP/$TOTAL_STEPS] Skipping Flutter build (--skip-build)"
-    # Search for worker binary in arch-specific and default target directories
+    # Search for worker binary in arch-specific and default target directories.
+    # For universal, the CI worker-build step lipo's both slices into target/universal/.
     if [ "$ARCH" = "arm64" ] && [ -f "$PROJECT_ROOT/worker/target/aarch64-apple-darwin/release/vapourbox-worker" ]; then
         WORKER_BIN="$PROJECT_ROOT/worker/target/aarch64-apple-darwin/release/vapourbox-worker"
     elif [ "$ARCH" = "x64" ] && [ -f "$PROJECT_ROOT/worker/target/x86_64-apple-darwin/release/vapourbox-worker" ]; then
         WORKER_BIN="$PROJECT_ROOT/worker/target/x86_64-apple-darwin/release/vapourbox-worker"
+    elif [ "$ARCH" = "universal" ] && [ -f "$PROJECT_ROOT/worker/target/universal/release/vapourbox-worker" ]; then
+        WORKER_BIN="$PROJECT_ROOT/worker/target/universal/release/vapourbox-worker"
     else
         WORKER_BIN="$PROJECT_ROOT/worker/target/release/vapourbox-worker"
     fi

--- a/app/macos/Podfile
+++ b/app/macos/Podfile
@@ -3,8 +3,9 @@ platform :osx, '10.15'
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
-# Build for Apple Silicon only
-ENV['ARCHS'] = 'arm64'
+# Target architecture: defaults to Apple Silicon. Set VAPOURBOX_ARCHS=x86_64
+# (e.g. for the Intel/x64 build) to override.
+ENV['ARCHS'] = ENV['VAPOURBOX_ARCHS'] || 'arm64'
 
 project 'Runner', {
   'Debug' => :debug,
@@ -39,12 +40,17 @@ target 'Runner' do
 end
 
 post_install do |installer|
+  # Build for the requested architecture(s). VAPOURBOX_ARCHS may be 'arm64',
+  # 'x86_64', or 'arm64 x86_64' (universal). Exclude whatever isn't being built
+  # so xcodebuild doesn't try to produce slices we lack dependencies for;
+  # a universal build excludes nothing.
+  build_archs = ENV['VAPOURBOX_ARCHS'] || 'arm64'
+  excluded_arch = (['arm64', 'x86_64'] - build_archs.split(' ')).join(' ')
   installer.pods_project.targets.each do |target|
     flutter_additional_macos_build_settings(target)
-    # Build for Apple Silicon only
     target.build_configurations.each do |config|
-      config.build_settings['ARCHS'] = 'arm64'
-      config.build_settings['EXCLUDED_ARCHS[sdk=macosx*]'] = 'x86_64'
+      config.build_settings['ARCHS'] = build_archs
+      config.build_settings['EXCLUDED_ARCHS[sdk=macosx*]'] = excluded_arch
     end
   end
 end

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -70,10 +70,33 @@ VapourBox/
 .\Scripts\download-deps-windows.ps1
 ```
 
-**macOS:**
+**macOS (arm64, native):**
 ```bash
 ./Scripts/download-deps-macos.sh
 ```
+
+**macOS (x64):** GitHub's Intel `macos-13` runner was retired (Dec 2025), so the
+x64 dependency bundle is built on an Apple Silicon machine through Rosetta 2 with
+an Intel Homebrew prefix. `uname -m` then reports `x86_64`, so the script targets
+`deps/macos-x64`, and every build tool (Homebrew, meson, ninja, clang, the
+embedded Python) emits x86_64. FFmpeg is sourced pre-built from
+[evermeet.cx](https://evermeet.cx/ffmpeg/) (static x86_64); `tmedian` and
+`bestsource` come pre-built from
+[Stefan-Olt/vs-plugin-build](https://github.com/Stefan-Olt/vs-plugin-build); the
+rest build from source.
+
+```bash
+# One-time: install Rosetta 2 and an Intel Homebrew at /usr/local
+softwareupdate --install-rosetta --agree-to-license
+arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Build the x64 deps
+arch -x86_64 /bin/bash -lc 'PATH=/usr/local/bin:$PATH ./Scripts/download-deps-macos.sh --force'
+```
+
+In CI, both architectures are produced by the **Build macOS Deps**
+(`build-deps-macos.yml`) workflow — the arm64 job runs natively on `macos-15`,
+the x64 job runs the same script under Rosetta.
 
 ## Development Builds
 
@@ -146,9 +169,19 @@ Output: `dist/VapourBox-1.0.0-windows-x64.zip`
 
 ### macOS
 ```bash
-./Scripts/package-macos.sh --version 1.0.0 [--skip-build]
+./Scripts/package-macos.sh --version 1.0.0 [--arch arm64|x64|universal] [--skip-build]
 ```
-Output: `dist/VapourBox.app` and `dist/VapourBox-1.0.0-macos-arm64.dmg`
+`--arch` defaults to the host architecture. **`universal`** produces a fat
+arm64+x86_64 bundle (the Rust worker is built for both targets and combined with
+`lipo`; the Flutter Runner is built with `ARCHS="arm64 x86_64"`). Output:
+`dist/VapourBox.app` and `dist/VapourBox-1.0.0-macos-<arch>.dmg`.
+
+In CI the **Build macOS** (`build-macos.yml`) workflow takes
+`arch: universal | both | arm64 | x64` (default **universal** — one DMG for all
+Macs; `both` emits two separate single-arch DMGs). The processing dependencies
+are **not** bundled — a universal app downloads the arch-appropriate deps
+(`macos-arm64` or `macos-x64`) on first run, so both deps bundles must be
+published for a universal release.
 
 ### Testing a Packaged Build
 


### PR DESCRIPTION
## Summary
Adds an **x86_64 macOS** dependency build and a **universal (arm64+x86_64)** app build.

- `download-deps-macos.sh`: x64 path sources FFmpeg pre-built from evermeet.cx, fftw/boost/libdvdread from Intel Homebrew, and adds `descratch` (source) + `tmedian`/`bestsource` (pre-built from Stefan-Olt) for parity with the shipped arm64 set. Built on Apple Silicon via **Rosetta 2** (Intel `macos-13` runner retired Dec 2025).
- New **`build-deps-macos.yml`** (arm64 native + x64 via Rosetta on `macos-15`).
- **`build-macos.yml`**: `arch = universal | both | arm64 | x64` (default `universal`) via a matrix; universal leg `lipo`s the worker and builds the Runner with `ARCHS="arm64 x86_64"`.
- `app/macos/Podfile` reads `VAPOURBOX_ARCHS`; `package-macos.sh --arch universal` builds the fat bundle.
- Deps stay per-arch (downloaded at runtime per `uname`), so a universal app needs **both** deps zips published.

## Validation
- Rust worker tests pass as **x86_64 via Rosetta** (158 passed; the 1 failure is the env-gated whisper-model test).
- Flutter tests: 166 passed / 3 skipped (native; SDK is arm64-only).
- Flutter engine xcframework confirmed universal (`arm64 x86_64`).

## Follow-up (after merge)
1. Run `build-deps-macos.yml` (arch `x64`) → publishes `VapourBox-deps-1.3.0-macos-x64.zip` to `deps-v1.3.0`.
2. Fill `app/assets/deps-version.json` → `macos-x64.sha256`/`.size`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)