### PR TITLE
Add Linux support (x86_64 + aarch64)

### DIFF
--- a/.github/workflows/build-deps-linux.yml
+++ b/.github/workflows/build-deps-linux.yml
@@ -11,12 +11,22 @@ on:
         description: 'Upload to this release tag (e.g., deps-v1.3.0). Leave empty to skip upload.'
         required: false
         type: string
+      arch:
+        description: 'Architecture to build'
+        required: false
+        type: choice
+        options:
+          - both
+          - x64
+          - arm64
+        default: both
 
 permissions:
   contents: write
 
 jobs:
   build-x64:
+    if: ${{ inputs.arch == 'x64' || inputs.arch == 'both' }}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -51,6 +61,7 @@ jobs:
             "dist/VapourBox-deps-${{ inputs.version }}-linux-x64.zip" --clobber
 
   build-arm64:
+    if: ${{ inputs.arch == 'arm64' || inputs.arch == 'both' }}
     runs-on: ubuntu-22.04-arm
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -22,24 +22,9 @@ on:
         default: x64
 
 jobs:
-  build:
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-22.04
-            arch: x64
-            flutter_arch: x64
-            rust_target: x86_64-unknown-linux-gnu
-          - os: ubuntu-22.04-arm
-            arch: arm64
-            flutter_arch: arm64
-            rust_target: aarch64-unknown-linux-gnu
-      fail-fast: false
-
-    runs-on: ${{ matrix.os }}
-
-    # Only run the job if it matches the requested arch (or both)
-    if: ${{ inputs.arch == 'both' || inputs.arch == matrix.arch }}
+  build-x64:
+    if: ${{ inputs.arch == 'both' || inputs.arch == 'x64' }}
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository
@@ -60,7 +45,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.rust_target }}
+          targets: x86_64-unknown-linux-gnu
 
       - name: Cache Rust dependencies
         uses: actions/cache@v4
@@ -71,21 +56,21 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             worker/target/
-          key: ${{ runner.os }}-${{ matrix.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-x64-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.arch }}-cargo-
+            ${{ runner.os }}-x64-cargo-
 
       - name: Download Linux dependencies
         run: |
           DEPS_VERSION="${{ inputs.deps_tag }}"
           DEPS_VERSION="${DEPS_VERSION#deps-v}"
 
-          mkdir -p deps/linux-${{ matrix.arch }}
+          mkdir -p deps/linux-x64
 
-          DEPS_URL="https://github.com/${{ github.repository }}/releases/download/${{ inputs.deps_tag }}/VapourBox-deps-${DEPS_VERSION}-linux-${{ matrix.arch }}.zip"
+          DEPS_URL="https://github.com/${{ github.repository }}/releases/download/${{ inputs.deps_tag }}/VapourBox-deps-${DEPS_VERSION}-linux-x64.zip"
           echo "Downloading deps from: $DEPS_URL"
           curl -L -o deps.zip "$DEPS_URL"
-          unzip -o deps.zip -d deps/linux-${{ matrix.arch }}
+          unzip -o deps.zip -d deps/linux-x64
           rm -f deps.zip
 
           echo "Dependencies extracted:"
@@ -110,10 +95,10 @@ jobs:
       - name: Build Rust worker
         run: |
           cd worker
-          cargo build --release --target ${{ matrix.rust_target }}
+          cargo build --release --target x86_64-unknown-linux-gnu
           # Copy to default release location for package script
           mkdir -p target/release
-          cp target/${{ matrix.rust_target }}/release/vapourbox-worker target/release/ || true
+          cp target/x86_64-unknown-linux-gnu/release/vapourbox-worker target/release/ || true
 
       - name: Build Flutter app
         run: |
@@ -124,10 +109,105 @@ jobs:
 
       - name: Package release
         run: |
-          ./Scripts/package-linux.sh --version "${{ inputs.version }}" --arch ${{ matrix.arch }} --skip-build
+          ./Scripts/package-linux.sh --version "${{ inputs.version }}" --arch x64 --skip-build
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: VapourBox-${{ inputs.version }}-linux-${{ matrix.arch }}
-          path: dist/VapourBox-${{ inputs.version }}-linux-${{ matrix.arch }}.tar.gz
+          name: VapourBox-${{ inputs.version }}-linux-x64
+          path: dist/VapourBox-${{ inputs.version }}-linux-x64.tar.gz
+
+  build-arm64:
+    if: ${{ inputs.arch == 'both' || inputs.arch == 'arm64' }}
+    runs-on: ubuntu-22.04-arm
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake git ninja-build pkg-config \
+            libgtk-3-dev liblzma-dev libstdc++-12-dev
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-gnu
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            worker/target/
+          key: ${{ runner.os }}-arm64-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-arm64-cargo-
+
+      - name: Download Linux dependencies
+        run: |
+          DEPS_VERSION="${{ inputs.deps_tag }}"
+          DEPS_VERSION="${DEPS_VERSION#deps-v}"
+
+          mkdir -p deps/linux-arm64
+
+          DEPS_URL="https://github.com/${{ github.repository }}/releases/download/${{ inputs.deps_tag }}/VapourBox-deps-${DEPS_VERSION}-linux-arm64.zip"
+          echo "Downloading deps from: $DEPS_URL"
+          curl -L -o deps.zip "$DEPS_URL"
+          unzip -o deps.zip -d deps/linux-arm64
+          rm -f deps.zip
+
+          echo "Dependencies extracted:"
+          ls -la deps/
+
+      - name: Update version numbers
+        run: |
+          VERSION="${{ inputs.version }}"
+          DEPS_TAG="${{ inputs.deps_tag }}"
+          DEPS_VERSION="${DEPS_TAG#deps-v}"
+
+          # Update pubspec.yaml
+          sed -i "s/^version: .*/version: ${VERSION}+1/" app/pubspec.yaml
+
+          # Update deps-version.json
+          sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"${DEPS_VERSION}\"/" app/assets/deps-version.json
+          sed -i "s/\"releaseTag\": \"[^\"]*\"/\"releaseTag\": \"${DEPS_TAG}\"/" app/assets/deps-version.json
+
+          # Update Cargo.toml
+          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" worker/Cargo.toml
+
+      - name: Build Rust worker
+        run: |
+          cd worker
+          cargo build --release --target aarch64-unknown-linux-gnu
+          # Copy to default release location for package script
+          mkdir -p target/release
+          cp target/aarch64-unknown-linux-gnu/release/vapourbox-worker target/release/ || true
+
+      - name: Build Flutter app
+        run: |
+          cd app
+          flutter pub get
+          dart run build_runner build --delete-conflicting-outputs
+          flutter build linux --release
+
+      - name: Package release
+        run: |
+          ./Scripts/package-linux.sh --version "${{ inputs.version }}" --arch arm64 --skip-build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: VapourBox-${{ inputs.version }}-linux-arm64
+          path: dist/VapourBox-${{ inputs.version }}-linux-arm64.tar.gz

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -132,10 +132,15 @@ jobs:
             libgtk-3-dev liblzma-dev libstdc++-12-dev
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: 'stable'
-          cache: true
+        run: |
+          git clone https://github.com/flutter/flutter.git -b stable --depth 1 "$HOME/flutter"
+          echo "$HOME/flutter/bin" >> "$GITHUB_PATH"
+
+      - name: Flutter precache
+        run: |
+          export PATH="$HOME/flutter/bin:$PATH"
+          flutter precache --linux
+          flutter --version
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,133 @@
+name: Build Linux
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number (e.g., 0.9.0)'
+        required: true
+        type: string
+      deps_tag:
+        description: 'Deps release tag (e.g., deps-v1.3.0)'
+        required: true
+        type: string
+      arch:
+        description: 'Architecture'
+        required: false
+        type: choice
+        options:
+          - x64
+          - arm64
+          - both
+        default: x64
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            arch: x64
+            flutter_arch: x64
+            rust_target: x86_64-unknown-linux-gnu
+          - os: ubuntu-22.04-arm
+            arch: arm64
+            flutter_arch: arm64
+            rust_target: aarch64-unknown-linux-gnu
+      fail-fast: false
+
+    runs-on: ${{ matrix.os }}
+
+    # Only run the job if it matches the requested arch (or both)
+    if: ${{ inputs.arch == 'both' || inputs.arch == matrix.arch }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake git ninja-build pkg-config \
+            libgtk-3-dev liblzma-dev libstdc++-12-dev
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust_target }}
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            worker/target/
+          key: ${{ runner.os }}-${{ matrix.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.arch }}-cargo-
+
+      - name: Download Linux dependencies
+        run: |
+          DEPS_VERSION="${{ inputs.deps_tag }}"
+          DEPS_VERSION="${DEPS_VERSION#deps-v}"
+
+          mkdir -p deps/linux-${{ matrix.arch }}
+
+          DEPS_URL="https://github.com/${{ github.repository }}/releases/download/${{ inputs.deps_tag }}/VapourBox-deps-${DEPS_VERSION}-linux-${{ matrix.arch }}.zip"
+          echo "Downloading deps from: $DEPS_URL"
+          curl -L -o deps.zip "$DEPS_URL"
+          unzip -o deps.zip -d deps/linux-${{ matrix.arch }}
+          rm -f deps.zip
+
+          echo "Dependencies extracted:"
+          ls -la deps/
+
+      - name: Update version numbers
+        run: |
+          VERSION="${{ inputs.version }}"
+          DEPS_TAG="${{ inputs.deps_tag }}"
+          DEPS_VERSION="${DEPS_TAG#deps-v}"
+
+          # Update pubspec.yaml
+          sed -i "s/^version: .*/version: ${VERSION}+1/" app/pubspec.yaml
+
+          # Update deps-version.json
+          sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"${DEPS_VERSION}\"/" app/assets/deps-version.json
+          sed -i "s/\"releaseTag\": \"[^\"]*\"/\"releaseTag\": \"${DEPS_TAG}\"/" app/assets/deps-version.json
+
+          # Update Cargo.toml
+          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" worker/Cargo.toml
+
+      - name: Build Rust worker
+        run: |
+          cd worker
+          cargo build --release --target ${{ matrix.rust_target }}
+          # Copy to default release location for package script
+          mkdir -p target/release
+          cp target/${{ matrix.rust_target }}/release/vapourbox-worker target/release/ || true
+
+      - name: Build Flutter app
+        run: |
+          cd app
+          flutter pub get
+          dart run build_runner build --delete-conflicting-outputs
+          flutter build linux --release
+
+      - name: Package release
+        run: |
+          ./Scripts/package-linux.sh --version "${{ inputs.version }}" --arch ${{ matrix.arch }} --skip-build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: VapourBox-${{ inputs.version }}-linux-${{ matrix.arch }}
+          path: dist/VapourBox-${{ inputs.version }}-linux-${{ matrix.arch }}.tar.gz

--- a/.github/workflows/build-whisper.yml
+++ b/.github/workflows/build-whisper.yml
@@ -1,0 +1,143 @@
+name: Build Whisper
+
+# Builds whisper.cpp's whisper-cli for Linux (x64 + arm64) and publishes the
+# binaries to a release. whisper.cpp ships no Linux binary (macOS uses a
+# Homebrew bottle, Windows a release zip), so VapourBox self-hosts the Linux
+# whisper-cli that the app downloads at runtime — see assets/whisper-addon.json.
+#
+# The binary is built fully static (no libgomp/libstdc++/libgcc runtime deps)
+# so it runs on any glibc >= 2.35 distro (Ubuntu 22.04+), matching the deps.
+#
+# Mirrors build-deps-{macos,linux}.yml: workflow_dispatch with version /
+# release_tag / arch inputs and per-arch jobs that build, package, upload an
+# artifact, and (optionally) upload to a release.
+
+on:
+  workflow_dispatch:
+    inputs:
+      whisper_version:
+        description: 'whisper.cpp tag to build (e.g., v1.8.3)'
+        required: true
+        type: string
+        default: v1.8.3
+      release_tag:
+        description: 'Upload to this release tag (e.g., whisper-v1.8.3). Leave empty to skip upload.'
+        required: false
+        type: string
+      arch:
+        description: 'Architecture to build'
+        required: false
+        type: choice
+        options:
+          - both
+          - x64
+          - arm64
+        default: both
+
+permissions:
+  contents: write
+
+jobs:
+  build-x64:
+    if: ${{ inputs.arch == 'x64' || inputs.arch == 'both' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build build-essential git
+
+      - name: Build whisper-cli (static)
+        run: |
+          git clone --depth 1 -b "${{ inputs.whisper_version }}" \
+            https://github.com/ggml-org/whisper.cpp /tmp/whisper.cpp
+          cmake -S /tmp/whisper.cpp -B /tmp/whisper.cpp/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DGGML_NATIVE=OFF \
+            -DGGML_OPENMP=OFF \
+            -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++"
+          cmake --build /tmp/whisper.cpp/build --config Release -j"$(nproc)"
+
+      - name: Package tarball
+        run: |
+          mkdir -p out/bin
+          cp "$(find /tmp/whisper.cpp/build -name whisper-cli -type f | head -1)" out/bin/whisper-cli
+          chmod +x out/bin/whisper-cli
+          echo "=== whisper-cli runtime deps (should be glibc only) ==="
+          ldd out/bin/whisper-cli || true
+          tar -C out -czf whisper-cli-linux-x64.tar.gz bin
+          echo "=== artifact ==="
+          ls -l whisper-cli-linux-x64.tar.gz
+          echo "size=$(stat -c%s whisper-cli-linux-x64.tar.gz)"
+          echo "sha256=$(sha256sum whisper-cli-linux-x64.tar.gz | cut -d' ' -f1)"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: whisper-cli-linux-x64
+          path: whisper-cli-linux-x64.tar.gz
+
+      - name: Upload to release
+        if: inputs.release_tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Create the release if it does not exist (|| true tolerates a race
+          # with the sibling arch job creating it concurrently).
+          gh release view "${{ inputs.release_tag }}" >/dev/null 2>&1 || \
+            gh release create "${{ inputs.release_tag }}" \
+              --title "${{ inputs.release_tag }}" \
+              --notes "whisper.cpp ${{ inputs.whisper_version }} whisper-cli binaries for Linux (built by build-whisper.yml)." \
+              || true
+          gh release upload "${{ inputs.release_tag }}" whisper-cli-linux-x64.tar.gz --clobber
+
+  build-arm64:
+    if: ${{ inputs.arch == 'arm64' || inputs.arch == 'both' }}
+    runs-on: ubuntu-22.04-arm
+    steps:
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build build-essential git
+
+      - name: Build whisper-cli (static)
+        run: |
+          git clone --depth 1 -b "${{ inputs.whisper_version }}" \
+            https://github.com/ggml-org/whisper.cpp /tmp/whisper.cpp
+          cmake -S /tmp/whisper.cpp -B /tmp/whisper.cpp/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DGGML_NATIVE=OFF \
+            -DGGML_OPENMP=OFF \
+            -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++"
+          cmake --build /tmp/whisper.cpp/build --config Release -j"$(nproc)"
+
+      - name: Package tarball
+        run: |
+          mkdir -p out/bin
+          cp "$(find /tmp/whisper.cpp/build -name whisper-cli -type f | head -1)" out/bin/whisper-cli
+          chmod +x out/bin/whisper-cli
+          echo "=== whisper-cli runtime deps (should be glibc only) ==="
+          ldd out/bin/whisper-cli || true
+          tar -C out -czf whisper-cli-linux-arm64.tar.gz bin
+          echo "=== artifact ==="
+          ls -l whisper-cli-linux-arm64.tar.gz
+          echo "size=$(stat -c%s whisper-cli-linux-arm64.tar.gz)"
+          echo "sha256=$(sha256sum whisper-cli-linux-arm64.tar.gz | cut -d' ' -f1)"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: whisper-cli-linux-arm64
+          path: whisper-cli-linux-arm64.tar.gz
+
+      - name: Upload to release
+        if: inputs.release_tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view "${{ inputs.release_tag }}" >/dev/null 2>&1 || \
+            gh release create "${{ inputs.release_tag }}" \
+              --title "${{ inputs.release_tag }}" \
+              --notes "whisper.cpp ${{ inputs.whisper_version }} whisper-cli binaries for Linux (built by build-whisper.yml)." \
+              || true
+          gh release upload "${{ inputs.release_tag }}" whisper-cli-linux-arm64.tar.gz --clobber

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -3,7 +3,7 @@ name: CI Tests
 # Pulls the published dependency bundle + the whisper add-on (binary + small
 # model) and runs the full Rust and Flutter test suites, including the subtitle
 # integration test. macOS is tested natively on both arm64 (macos-15) and x64
-# (macos-15-intel); Windows on x64.
+# (macos-15-intel); Windows on x64; Linux on x64 (ubuntu-22.04).
 
 on:
   push:
@@ -161,6 +161,95 @@ jobs:
           cp "$(dirname "$CLI")"/*.exe addons/whisper/ 2>/dev/null || true
           cp "$(dirname "$CLI")"/*.dll addons/whisper/ 2>/dev/null || true
           ls addons/whisper/
+
+      - name: Rust tests
+        run: cd worker && cargo test -- --nocapture
+
+      - name: Generate Dart serialization
+        run: |
+          cd app
+          flutter pub get
+          dart run build_runner build --delete-conflicting-outputs
+
+      - name: Flutter tests
+        run: cd app && flutter test
+
+  linux:
+    runs-on: ubuntu-22.04  # matches the deps-build runner (glibc compatibility)
+    env:
+      # Dart ToolLocator/DependencyManager honour this; the Rust locator does
+      # not (it uses the XDG path), so we also symlink it below.
+      VAPOURBOX_DEPS_DIR: ${{ github.workspace }}/deps/linux-x64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake ninja-build pkg-config \
+            libgtk-3-dev liblzma-dev unzip
+
+      - name: Resolve deps tag
+        id: deps
+        run: |
+          TAG=$(python3 -c "import json;print(json.load(open('app/assets/deps-version.json'))['releaseTag'])")
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "ver=${TAG#deps-v}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Download dependencies (linux-x64)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VER="${{ steps.deps.outputs.ver }}"
+          ZIP="VapourBox-deps-${VER}-linux-x64.zip"
+          mkdir -p deps/linux-x64
+          gh release download "${{ steps.deps.outputs.tag }}" --pattern "$ZIP" --dir . --clobber
+          unzip -q -o "$ZIP" -d deps/linux-x64
+          rm -f "$ZIP"
+
+      - name: Cache whisper model
+        uses: actions/cache@v4
+        with:
+          path: .whisper-cache
+          key: whisper-ggml-small-v1
+
+      - name: Provision whisper add-on
+        run: |
+          mkdir -p .whisper-cache addons/whisper/models addons/whisper/bin
+          if [ ! -f .whisper-cache/ggml-small.bin ]; then
+            echo "Downloading whisper small model..."
+            curl -L -o .whisper-cache/ggml-small.bin "$WHISPER_MODEL_URL"
+          fi
+          cp .whisper-cache/ggml-small.bin addons/whisper/models/ggml-small.bin
+          # No prebuilt Linux whisper-cli is published (macOS uses a Homebrew
+          # bottle, Windows a release zip), so build whisper.cpp from source.
+          # Static build (BUILD_SHARED_LIBS=OFF) => a self-contained whisper-cli
+          # with no lib/ dir to manage; GGML_NATIVE=OFF for runner portability.
+          git clone --depth 1 -b v1.8.3 https://github.com/ggml-org/whisper.cpp /tmp/whisper.cpp
+          cmake -S /tmp/whisper.cpp -B /tmp/whisper.cpp/build \
+            -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DGGML_NATIVE=OFF
+          cmake --build /tmp/whisper.cpp/build --config Release -j"$(nproc)"
+          cp "$(find /tmp/whisper.cpp/build -name whisper-cli -type f | head -1)" addons/whisper/bin/whisper-cli
+          chmod +x addons/whisper/bin/whisper-cli
+          ls -la addons/whisper/bin addons/whisper/models
+
+      - name: Stage deps/addons at XDG path for the Rust locator
+        # The Rust DependencyLocator on Linux only looks under
+        # ~/.local/share/VapourBox (no debug upward-search); the Dart tests use
+        # the repo-root copy. Symlink so a single checkout satisfies both.
+        run: |
+          mkdir -p "$HOME/.local/share/VapourBox"
+          ln -sfn "${{ github.workspace }}/deps" "$HOME/.local/share/VapourBox/deps"
+          ln -sfn "${{ github.workspace }}/addons" "$HOME/.local/share/VapourBox/addons"
 
       - name: Rust tests
         run: cd worker && cargo test -- --nocapture

--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,6 @@ app/windows/flutter/generated_plugins.cmake
 # Platform-specific (unsupported platforms)
 app/android/
 app/ios/
-app/linux/
 app/web/
 
 # =============================================================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Both files should stay synchronized - README.md is for humans, CLAUDE.md is for 
 
 ## Project Overview
 
-VapourBox is a **cross-platform** (macOS + Windows) video processing application using VapourSynth. It provides a simple drag-and-drop interface for deinterlacing, denoising, sharpening, and other video processing tasks as an alternative to more complex tools like Hybrid.
+VapourBox is a **cross-platform** (macOS + Windows + Linux) video processing application using VapourSynth. It provides a simple drag-and-drop interface for deinterlacing, denoising, sharpening, and other video processing tasks as an alternative to more complex tools like Hybrid.
 
 **Technology Stack:**
 - **UI**: Flutter (Dart) - cross-platform desktop app
@@ -56,7 +56,8 @@ VapourBox/
 │   ├── assets/filters/         # Built-in filter schemas (JSON)
 │   │   └── core/               # Core filters (deinterlace, denoise, etc.)
 │   ├── macos/                  # macOS platform config
-│   └── windows/                # Windows platform config
+│   ├── windows/                # Windows platform config
+│   └── linux/                  # Linux platform config
 │
 ├── worker/                     # Rust worker crate
 │   ├── src/
@@ -72,7 +73,9 @@ VapourBox/
 ├── deps/                       # Platform-specific dependencies
 │   ├── macos-arm64/            # Python 3.12, VS, FFmpeg, plugins
 │   ├── macos-x64/
-│   └── windows-x64/            # VSPipe, Python 3.8, FFmpeg, plugins
+│   ├── windows-x64/            # VSPipe, Python 3.8, FFmpeg, plugins
+│   ├── linux-x64/              # Python 3.12, VS, FFmpeg, plugins
+│   └── linux-arm64/
 │
 ├── licenses/                   # GPL, LGPL, NOTICES
 ├── Scripts/                    # Build, package, and release scripts
@@ -109,12 +112,13 @@ VapourBox/
 - Rust 1.70+
 - Windows: Visual Studio Build Tools with C++ workload
 - macOS: Xcode Command Line Tools
+- Linux: `clang cmake git ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev`
 
 ### Download Dependencies
 
 ```bash
 # macOS arm64 (native, on Apple Silicon)
-./scripts/download-deps-macos.sh
+./Scripts/download-deps-macos.sh
 
 # macOS x64 (native, on an Intel Mac): same script — uname -m reports x86_64 so
 # it targets deps/macos-x64. FFmpeg comes pre-built from evermeet.cx, most
@@ -125,7 +129,10 @@ VapourBox/
 #   arch -x86_64 /bin/bash -lc 'PATH=/usr/local/bin:$PATH ./Scripts/download-deps-macos.sh --force'
 
 # Windows (PowerShell)
-.\scripts\download-deps-windows.ps1
+.\Scripts\download-deps-windows.ps1
+
+# Linux
+./Scripts/download-deps-linux.sh
 ```
 
 Both macOS architectures are produced in CI by `build-deps-macos.yml` (arm64 on
@@ -161,6 +168,11 @@ xcodebuild -workspace Runner.xcworkspace -scheme Pods-Runner -configuration Rele
 xcodebuild -workspace Runner.xcworkspace -scheme Runner -configuration Release build ARCHS=arm64 ONLY_ACTIVE_ARCH=YES
 mkdir -p ../build/macos/Build/Products/Release
 cp -R ~/Library/Developer/Xcode/DerivedData/Runner-*/Build/Products/Release/vapourbox.app ../build/macos/Build/Products/Release/
+```
+
+**Linux:**
+```bash
+cd app && flutter pub get && flutter build linux --release
 ```
 
 ### Generate Dart JSON Serialization
@@ -200,6 +212,15 @@ dart run build_runner build
 2. Copy worker: `cp worker/target/debug/vapourbox-worker.exe app/build/windows/x64/runner/Debug/`
 3. Run app: `cd app && flutter run`
 
+**Linux: Use the debug script:**
+
+```bash
+./Scripts/run-debug-linux.sh            # Full build (worker + app) and launch
+./Scripts/run-debug-linux.sh --skip-worker  # Rebuild app only
+./Scripts/run-debug-linux.sh --skip-app     # Rebuild worker only
+./Scripts/run-debug-linux.sh --run-only     # Just copy and launch
+```
+
 ### Production Packaging
 
 **IMPORTANT**: Never manually assemble a release build. Always use packaging scripts — the app will silently crash on video drop if the bundle is incomplete.
@@ -211,8 +232,14 @@ dart run build_runner build
 # Windows
 .\Scripts\package-windows.ps1 -Version "X.Y.Z" [-SkipBuild]
 
+# Linux
+./Scripts/package-linux.sh --version X.Y.Z [--skip-build]
+
 # Test packaged app from terminal to see errors:
+# macOS:
 dist/VapourBox.app/Contents/MacOS/vapourbox
+# Linux:
+dist/VapourBox-X.Y.Z-linux-x64/vapourbox
 ```
 
 Do NOT run `app/build/macos/Build/Products/Release/vapourbox.app` directly — it lacks templates and proper bundle structure.
@@ -454,7 +481,17 @@ The `download-deps-windows.ps1` and `download-deps-macos.sh` scripts apply these
 - Show in Folder: `open -R <path>`
 - **Apple Silicon app build for x64**: the `app/macos/Podfile` reads `VAPOURBOX_ARCHS` (default `arm64`); set it to `x86_64` and pass `ARCHS=x86_64` to xcodebuild to cross-compile the Intel Runner.
 
-Plugin lists for both platforms: see `deps/` directories or download scripts.
+### Linux
+
+- Bundled deps in `~/.local/share/VapourBox/deps/linux-{x64,arm64}/` (or `$XDG_DATA_HOME`)
+- Worker sets: `PYTHONHOME`, `PYTHONPATH`, `VAPOURSYNTH_CONF_PATH`, `LD_LIBRARY_PATH`
+- `patchelf` used for RPATH fixup (equivalent to macOS `install_name_tool`)
+- GPU/OpenCL: requires user-installed GPU driver; nnedi3cl degrades gracefully without it
+- Show in Folder: `xdg-open <directory>`
+- Debug builds: use `./Scripts/run-debug-linux.sh`
+- No code signing or quarantine removal needed
+
+Plugin lists for all platforms: see `deps/` directories or download scripts.
 
 ---
 
@@ -501,15 +538,19 @@ Prerequisites: draft release must exist for the tag, `gh` CLI authenticated.
 | `Scripts/check-deps-changed.sh` | Detect if deps changed since last release (exit 0=changed, 1=unchanged) |
 | `Scripts/package-macos.sh` | Package macOS app |
 | `Scripts/package-windows.ps1` | Package Windows app |
+| `Scripts/package-linux.sh` | Package Linux app |
 | `Scripts/package-deps-macos.sh` | Package macOS deps |
 | `Scripts/package-deps-windows.ps1` | Package Windows deps |
+| `Scripts/package-deps-linux.sh` | Package Linux deps |
+| `Scripts/download-deps-linux.sh` | Build Linux deps from source |
+| `Scripts/run-debug-linux.sh` | Dev build + run for Linux |
 
 ### Release Checklist
 
 1. **Confirm version** — ask user, update `pubspec.yaml`
 2. **Check deps** — run `check-deps-changed.sh`; if changed, bump version in `deps-version.json`
 3. **Build & package** — use packaging scripts (or `release.sh` for full automation)
-4. **Update `app/assets/deps-version.json`** — after packaging each platform's deps zip, update its `sha256` and `size` fields with the values printed by the packaging script. **Both platforms must have valid (non-null) sha256 and size before release.** The app uses these values to verify downloaded deps at runtime.
+4. **Update `app/assets/deps-version.json`** — after packaging each platform's deps zip, update its `sha256` and `size` fields with the values printed by the packaging script. **All platforms must have valid (non-null) sha256 and size before release.** The app uses these values to verify downloaded deps at runtime.
 5. **Test** — fresh install + upgrade test
 6. **Create GitHub releases** — deps release first (if changed, tag `deps-vX.Y.Z`), then app release (tag `vX.Y.Z`)
 
@@ -550,8 +591,10 @@ Create the app-specific password at appleid.apple.com → Sign-In and Security �
 ### Cross-Platform Notes
 
 - Flutter Windows can't build on macOS — use GitHub Actions
+- Flutter Linux can't build on macOS — use GitHub Actions or a Linux VM
 - Windows deps can be zipped on macOS if `deps/windows-x64/` exists
-- The macOS CI build (`build-macos.yml`) signs with the Developer ID cert and notarizes — see "macOS Code Signing & Notarization" below. Windows CI builds remain unsigned.
+- Linux deps must be built on Linux (`./Scripts/download-deps-linux.sh`)
+- The macOS CI build (`build-macos.yml`) signs with the Developer ID cert and notarizes — see "macOS Code Signing & Notarization" below. Windows and Linux CI builds remain unsigned.
 - macOS ships as a **universal** (arm64+x86_64) app by default. `build-macos.yml` takes an `arch` input (`universal` | `both` | `arm64` | `x64`, default `universal`) and fans out via a matrix. Universal = lipo'd worker + Runner built with `ARCHS="arm64 x86_64"`; `both` = two separate single-arch DMGs. The x64 slice cross-compiles on the `macos-15` (arm64) runner.
 - Deps are **not** bundled — the app downloads `macos-arm64` or `macos-x64` deps at runtime per `uname`, so a universal app needs **both** deps bundles published. macOS deps are built by `build-deps-macos.yml` (arm64 on `macos-15`, x64 natively on `macos-15-intel`).
 - `app/macos/Podfile` reads `VAPOURBOX_ARCHS` (default `arm64`; set to `x86_64` or `arm64 x86_64`); `package-macos.sh --arch universal` sets this and lipo's the worker.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Get the latest release for your platform:
 |----------|------|
 | macOS (Universal — Apple Silicon & Intel) | `VapourBox-x.x.x-macos-universal.dmg` |
 | Windows 10/11 (x64) | `VapourBox-x.x.x-windows-x64.zip` |
+| Linux (x64) | `VapourBox-x.x.x-linux-x64.tar.gz` |
+| Linux (arm64) | `VapourBox-x.x.x-linux-arm64.tar.gz` |
 
 > The macOS DMG is a universal binary that runs natively on both Apple Silicon and Intel Macs; the correct processing dependencies are downloaded for your CPU on first launch.
 
@@ -49,6 +51,15 @@ Get the latest release for your platform:
 2. Extract to a folder of your choice (e.g., `C:\VapourBox`)
 3. Run `vapourbox.exe`
 4. On first launch, VapourBox will automatically download its processing dependencies (~195 MB)
+
+### Linux
+
+1. Download the `.tar.gz` file for your architecture from the [releases page](https://github.com/StuartCameronCode/VapourBox/releases/latest)
+2. Extract: `tar -xzf VapourBox-x.x.x-linux-x64.tar.gz`
+3. Run: `cd VapourBox-x.x.x-linux-x64 && ./vapourbox`
+4. On first launch, VapourBox will automatically download its processing dependencies (~100 MB)
+
+> **GPU acceleration**: For GPU-accelerated deinterlacing (NNEDI3CL), install your GPU's OpenCL driver. Without it, VapourBox falls back to CPU-based processing automatically.
 
 ## Features
 
@@ -118,6 +129,17 @@ brew install libdvdcss
 **Windows:**
 
 Download `libdvdcss-2.dll` from [VideoLAN](https://www.videolan.org/developers/libdvdcss.html) and place it in the VapourBox application directory (next to `vapourbox.exe`).
+
+**Linux:**
+
+```bash
+# Debian/Ubuntu
+sudo apt install libdvdcss2
+# Fedora (RPM Fusion required)
+sudo dnf install libdvdcss
+# Arch
+sudo pacman -S libdvdcss
+```
 
 Unencrypted DVDs (home recordings, some independent releases) work without libdvdcss.
 

--- a/Scripts/check-deps-changed.sh
+++ b/Scripts/check-deps-changed.sh
@@ -20,8 +20,11 @@ DEPS_PATHS=(
     "deps/windows-x64/ffmpeg"
     "deps/macos-arm64"
     "deps/macos-x64"
+    "deps/linux-x64"
+    "deps/linux-arm64"
     "Scripts/download-deps-windows.ps1"
     "Scripts/download-deps-macos.sh"
+    "Scripts/download-deps-linux.sh"
 )
 
 # Get the last deps release tag

--- a/Scripts/ci-build-and-release.sh
+++ b/Scripts/ci-build-and-release.sh
@@ -101,6 +101,12 @@ if ! $SKIP_TRIGGER; then
         -f deps_tag="$DEPS_TAG" \
         -f arch="$ARCH"
 
+    echo "  Triggering Build Linux..."
+    gh workflow run "Build Linux" \
+        -f version="$VERSION" \
+        -f deps_tag="$DEPS_TAG" \
+        -f arch="both"
+
     # Wait for runs to appear (they take a moment to register)
     echo "  Waiting for runs to register..."
     sleep 10
@@ -111,12 +117,14 @@ if ! $SKIP_TRIGGER; then
 
     WIN_RUN_ID=$(gh run list --workflow "Build Windows" --limit 1 --json databaseId --jq '.[0].databaseId')
     MAC_RUN_ID=$(gh run list --workflow "Build macOS" --limit 1 --json databaseId --jq '.[0].databaseId')
+    LINUX_RUN_ID=$(gh run list --workflow "Build Linux" --limit 1 --json databaseId --jq '.[0].databaseId')
 
     echo "  Windows run: $WIN_RUN_ID"
     echo "  macOS run:   $MAC_RUN_ID"
+    echo "  Linux run:   $LINUX_RUN_ID"
     echo ""
 
-    # Wait for both to complete
+    # Wait for all to complete
     FAILED=false
 
     echo "  Waiting for Windows build..."
@@ -135,19 +143,30 @@ if ! $SKIP_TRIGGER; then
         FAILED=true
     fi
 
+    echo "  Waiting for Linux build..."
+    if gh run watch "$LINUX_RUN_ID" --exit-status; then
+        echo -e "  ${GREEN}Linux build succeeded${NC}"
+    else
+        echo -e "  ${RED}Linux build failed${NC}"
+        FAILED=true
+    fi
+
     if $FAILED; then
         echo ""
         echo -e "${RED}One or more builds failed. Check the runs:${NC}"
         echo "  Windows: gh run view $WIN_RUN_ID --web"
         echo "  macOS:   gh run view $MAC_RUN_ID --web"
+        echo "  Linux:   gh run view $LINUX_RUN_ID --web"
         exit 1
     fi
 else
     echo -e "${YELLOW}Skipping workflow trigger (--skip-trigger)${NC}"
     WIN_RUN_ID=$(gh run list --workflow "Build Windows" --limit 1 --json databaseId --jq '.[0].databaseId')
     MAC_RUN_ID=$(gh run list --workflow "Build macOS" --limit 1 --json databaseId --jq '.[0].databaseId')
+    LINUX_RUN_ID=$(gh run list --workflow "Build Linux" --limit 1 --json databaseId --jq '.[0].databaseId')
     echo "  Using latest Windows run: $WIN_RUN_ID"
     echo "  Using latest macOS run:   $MAC_RUN_ID"
+    echo "  Using latest Linux run:   $LINUX_RUN_ID"
 fi
 
 # Download artifacts
@@ -162,8 +181,11 @@ gh run download "$WIN_RUN_ID" --dir "$DOWNLOAD_DIR"
 echo "  Downloading macOS artifact..."
 gh run download "$MAC_RUN_ID" --dir "$DOWNLOAD_DIR"
 
+echo "  Downloading Linux artifact..."
+gh run download "$LINUX_RUN_ID" --dir "$DOWNLOAD_DIR"
+
 echo "  Downloaded artifacts:"
-find "$DOWNLOAD_DIR" -type f -name "*.zip" -o -name "*.dmg" | while read -r f; do
+find "$DOWNLOAD_DIR" -type f \( -name "*.zip" -o -name "*.dmg" -o -name "*.tar.gz" \) | while read -r f; do
     SIZE=$(du -sh "$f" | cut -f1)
     echo "    $(basename "$f") ($SIZE)"
 done
@@ -173,7 +195,7 @@ echo ""
 echo -e "${BLUE}[4/4] Uploading to release ${RELEASE_TAG}...${NC}"
 
 UPLOAD_COUNT=0
-find "$DOWNLOAD_DIR" -type f \( -name "*.zip" -o -name "*.dmg" \) | while read -r f; do
+find "$DOWNLOAD_DIR" -type f \( -name "*.zip" -o -name "*.dmg" -o -name "*.tar.gz" \) | while read -r f; do
     BASENAME=$(basename "$f")
     echo "  Uploading $BASENAME..."
     gh release upload "$RELEASE_TAG" "$f" --clobber

--- a/Scripts/download-deps-linux.sh
+++ b/Scripts/download-deps-linux.sh
@@ -571,10 +571,11 @@ build_plugin "nnedi3cl" \
     "$PLUGIN_BUILD_ENV meson setup build --buildtype=release && ninja -C build"
 
 # EEDI3m (edge-directed interpolation)
+# Patch: add missing <cstddef> include for std::max_align_t (GCC 13+)
 build_plugin "eedi3m" \
     "https://github.com/HomeOfVapourSynthEvolution/VapourSynth-EEDI3.git" \
     "libeedi3m.so" \
-    "$PLUGIN_BUILD_ENV meson setup build --buildtype=release && ninja -C build"
+    "sed -i '1i #include <cstddef>' EEDI3/EEDI3.cpp && $PLUGIN_BUILD_ENV meson setup build --buildtype=release && ninja -C build"
 
 # fmtconv (format conversion)
 echo ""

--- a/Scripts/download-deps-linux.sh
+++ b/Scripts/download-deps-linux.sh
@@ -711,6 +711,46 @@ build_plugin "knlmeanscl" \
     "libknlmeanscl.so" \
     "$PLUGIN_BUILD_ENV meson setup build --buildtype=release && ninja -C build"
 
+# TemporalMedian (core.tmedian.TemporalMedian - used by the SpotLess filter)
+build_plugin "tmedian" \
+    "https://github.com/dubhater/vapoursynth-temporalmedian.git" \
+    "libtmedian.so" \
+    "$PLUGIN_BUILD_ENV meson setup build --buildtype=release && ninja -C build"
+
+# DeScratch (core.descratch.DeScratch - vertical scratch removal)
+# Built from source: the repo carries the VapourSynth + AviSynthPlus headers as
+# submodules, so a recursive clone is required (build_plugin can't fetch those).
+echo ""
+echo "=== Building DeScratch ==="
+if [ "$FORCE" = true ] || [ ! -f "$PLUGINS_DIR/libdescratch.so" ]; then
+    rm -rf descratch
+    if git clone --depth 1 --recurse-submodules --shallow-submodules \
+        https://github.com/vapoursynth/descratch.git descratch; then
+        cd descratch
+        if meson setup build --buildtype=release && ninja -C build; then
+            lib_path=$(find build -name "*.so" -type f 2>/dev/null | head -1)
+            if [ -n "$lib_path" ]; then
+                cp "$lib_path" "$PLUGINS_DIR/libdescratch.so"
+                patchelf --set-rpath '$ORIGIN:$ORIGIN/../../lib' "$PLUGINS_DIR/libdescratch.so" 2>/dev/null || true
+                echo "  Built DeScratch -> libdescratch.so"
+                BUILT_PLUGINS+=("descratch")
+            else
+                echo "  Warning: No .so found for DeScratch"
+                FAILED_PLUGINS+=("descratch")
+            fi
+        else
+            echo "  Failed to build DeScratch"
+            FAILED_PLUGINS+=("descratch")
+        fi
+        cd "$BUILD_DIR"
+    else
+        echo "  Failed to clone DeScratch"
+        FAILED_PLUGINS+=("descratch")
+    fi
+else
+    echo "  DeScratch already exists, skipping"
+fi
+
 # ============================================================================
 # Download NNEDI3 weights
 # ============================================================================

--- a/Scripts/download-deps-linux.sh
+++ b/Scripts/download-deps-linux.sh
@@ -1,0 +1,966 @@
+#!/bin/bash
+# Download and build dependencies for VapourBox on Linux (x86_64/aarch64)
+# Builds VapourSynth plugins from source for native architecture support
+# Creates a fully self-contained app with no system runtime dependencies
+#
+# Prerequisites:
+#   sudo apt install -y meson ninja-build cmake nasm patchelf autoconf automake \
+#     libtool pkg-config gcc g++ git python3 cython3 \
+#     libfftw3-dev libboost-filesystem-dev libboost-atomic-dev \
+#     ocl-icd-opencl-dev libdvdread-dev
+#
+# Usage: ./Scripts/download-deps-linux.sh [--force]
+
+set -e
+
+FORCE=false
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --force)
+            FORCE=true
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: $0 [--force]"
+            exit 1
+            ;;
+    esac
+done
+
+# Detect architecture
+ARCH=$(uname -m)
+if [ "$ARCH" = "x86_64" ]; then
+    PLATFORM_DIR="linux-x64"
+elif [ "$ARCH" = "aarch64" ]; then
+    PLATFORM_DIR="linux-arm64"
+else
+    echo "Unsupported architecture: $ARCH"
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+DEPS_DIR="$PROJECT_ROOT/deps/$PLATFORM_DIR"
+PLUGINS_DIR="$DEPS_DIR/vapoursynth/plugins"
+PYTHON_DIR="$DEPS_DIR/python"
+PYTHON_PACKAGES_DIR="$DEPS_DIR/python-packages"
+BUILD_DIR="/tmp/vapourbox-build-$$"
+BUILD_PREFIX="$BUILD_DIR/install"
+NPROC=$(nproc)
+
+# Python version to embed
+PYTHON_VERSION="3.12.8"
+PYTHON_MAJOR_MINOR="3.12"
+
+echo "=== VapourBox Linux Dependencies Builder ==="
+echo "Architecture: $ARCH"
+echo "Platform: $PLATFORM_DIR"
+echo "Deps directory: $DEPS_DIR"
+echo "Build directory: $BUILD_DIR"
+echo "Force rebuild: $FORCE"
+echo "Parallel jobs: $NPROC"
+echo ""
+
+# ============================================================================
+# Check build prerequisites
+# ============================================================================
+echo "=== Checking build prerequisites ==="
+
+MISSING_DEPS=()
+for cmd in meson ninja cmake nasm patchelf pkg-config gcc g++ git autoconf automake libtoolize python3; do
+    if ! command -v "$cmd" &>/dev/null; then
+        MISSING_DEPS+=("$cmd")
+    fi
+done
+
+if [ ${#MISSING_DEPS[@]} -gt 0 ]; then
+    echo "ERROR: Missing build tools: ${MISSING_DEPS[*]}"
+    echo ""
+    echo "Install with:"
+    echo "  sudo apt install -y meson ninja-build cmake nasm patchelf autoconf automake \\"
+    echo "    libtool pkg-config gcc g++ git python3 cython3"
+    exit 1
+fi
+
+echo "  All build tools found"
+
+# Create directories
+mkdir -p "$DEPS_DIR"/{vapoursynth,ffmpeg,python,python-packages,lib,resources/NNEDI3CL}
+mkdir -p "$PLUGINS_DIR"
+mkdir -p "$BUILD_DIR"
+mkdir -p "$BUILD_PREFIX"/{lib,include,lib/pkgconfig}
+
+# ============================================================================
+# Download and embed Python
+# ============================================================================
+echo ""
+echo "=== Downloading embedded Python $PYTHON_VERSION ==="
+
+if [ "$FORCE" = true ] || [ ! -f "$PYTHON_DIR/bin/python${PYTHON_MAJOR_MINOR}" ]; then
+    if [ "$ARCH" = "x86_64" ]; then
+        PYTHON_STANDALONE_URL="https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-${PYTHON_VERSION}+20241206-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+    else
+        PYTHON_STANDALONE_URL="https://github.com/indygreg/python-build-standalone/releases/download/20241206/cpython-${PYTHON_VERSION}+20241206-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+    fi
+
+    echo "  Downloading python-build-standalone..."
+    curl -L -o "$BUILD_DIR/python-standalone.tar.gz" "$PYTHON_STANDALONE_URL"
+
+    echo "  Extracting Python..."
+    rm -rf "$PYTHON_DIR"/*
+    mkdir -p "$PYTHON_DIR"
+    tar -xzf "$BUILD_DIR/python-standalone.tar.gz" -C "$PYTHON_DIR" --strip-components=1
+
+    PYTHON_BIN="$PYTHON_DIR/bin/python${PYTHON_MAJOR_MINOR}"
+    echo "  Python installed to: $PYTHON_DIR"
+    "$PYTHON_BIN" --version
+else
+    echo "  Python already installed, skipping"
+fi
+
+# Set Python paths for building
+PYTHON_BIN="$PYTHON_DIR/bin/python${PYTHON_MAJOR_MINOR}"
+PYTHON_LIB="$PYTHON_DIR/lib/libpython${PYTHON_MAJOR_MINOR}.so"
+PYTHON_INCLUDE="$PYTHON_DIR/include/python${PYTHON_MAJOR_MINOR}"
+
+# ============================================================================
+# Build zimg from source (VapourSynth dependency)
+# ============================================================================
+echo ""
+echo "=== Building zimg ==="
+
+if [ "$FORCE" = true ] || [ ! -f "$BUILD_PREFIX/lib/libzimg.so" ]; then
+    cd "$BUILD_DIR"
+    rm -rf zimg
+    git clone --depth 1 --recursive https://github.com/sekrit-twc/zimg.git zimg
+    cd zimg
+    ./autogen.sh
+    ./configure --prefix="$BUILD_PREFIX"
+    make -j"$NPROC"
+    make install
+
+    # Copy to deps
+    cp "$BUILD_PREFIX/lib/libzimg.so"* "$DEPS_DIR/vapoursynth/"
+    echo "  Built zimg"
+else
+    echo "  zimg already built, skipping"
+fi
+
+# ============================================================================
+# Build VapourSynth from source with embedded Python
+# ============================================================================
+echo ""
+echo "=== Building VapourSynth from source ==="
+
+VS_BUILD_DIR="$BUILD_DIR/vapoursynth"
+VS_INSTALL_DIR="$BUILD_DIR/vapoursynth-install"
+
+if [ "$FORCE" = true ] || [ ! -f "$DEPS_DIR/vapoursynth/libvapoursynth.so" ]; then
+    echo "  Cloning VapourSynth R73..."
+    rm -rf "$VS_BUILD_DIR"
+    git clone --depth 1 --branch R73 https://github.com/vapoursynth/vapoursynth.git "$VS_BUILD_DIR" 2>/dev/null || \
+    git clone --depth 1 https://github.com/vapoursynth/vapoursynth.git "$VS_BUILD_DIR"
+
+    cd "$VS_BUILD_DIR"
+
+    # Install Cython in our embedded Python for building
+    echo "  Installing Cython in embedded Python..."
+    "$PYTHON_BIN" -m pip install --quiet cython
+
+    # Create pkg-config file for our embedded Python
+    mkdir -p "$BUILD_DIR/pkgconfig"
+    cat > "$BUILD_DIR/pkgconfig/python3.pc" << EOF
+prefix=$PYTHON_DIR
+exec_prefix=\${prefix}
+libdir=\${prefix}/lib
+includedir=\${prefix}/include
+
+Name: Python
+Description: Embedded Python
+Version: $PYTHON_VERSION
+Libs: -L\${libdir} -lpython${PYTHON_MAJOR_MINOR}
+Cflags: -I\${includedir}/python${PYTHON_MAJOR_MINOR}
+EOF
+    cat > "$BUILD_DIR/pkgconfig/python-${PYTHON_MAJOR_MINOR}.pc" << EOF
+prefix=$PYTHON_DIR
+exec_prefix=\${prefix}
+libdir=\${prefix}/lib
+includedir=\${prefix}/include
+
+Name: Python
+Description: Embedded Python
+Version: $PYTHON_VERSION
+Libs: -L\${libdir} -lpython${PYTHON_MAJOR_MINOR}
+Cflags: -I\${includedir}/python${PYTHON_MAJOR_MINOR}
+EOF
+    cp "$BUILD_DIR/pkgconfig/python-${PYTHON_MAJOR_MINOR}.pc" "$BUILD_DIR/pkgconfig/python3-embed.pc"
+
+    # Copy zimg pkg-config from the build (has correct version)
+    if [ -f "$BUILD_PREFIX/lib/pkgconfig/zimg.pc" ]; then
+        cp "$BUILD_PREFIX/lib/pkgconfig/zimg.pc" "$BUILD_DIR/pkgconfig/"
+    fi
+
+    echo "  Configuring VapourSynth..."
+    PATH="$PYTHON_DIR/bin:$PATH" \
+    PKG_CONFIG_PATH="$BUILD_DIR/pkgconfig:$BUILD_PREFIX/lib/pkgconfig" \
+    LD_LIBRARY_PATH="$PYTHON_DIR/lib:$BUILD_PREFIX/lib:${LD_LIBRARY_PATH:-}" \
+    meson setup build \
+        --prefix="$VS_INSTALL_DIR" \
+        --buildtype=release \
+        -Dlibdir=lib \
+        -Dplugindir="" \
+        -Dpython3_bin="$PYTHON_BIN"
+
+    echo "  Building VapourSynth..."
+    PATH="$PYTHON_DIR/bin:$PATH" \
+    LD_LIBRARY_PATH="$PYTHON_DIR/lib:$BUILD_PREFIX/lib:${LD_LIBRARY_PATH:-}" \
+    ninja -C build
+    PATH="$PYTHON_DIR/bin:$PATH" \
+    LD_LIBRARY_PATH="$PYTHON_DIR/lib:$BUILD_PREFIX/lib:${LD_LIBRARY_PATH:-}" \
+    ninja -C build install
+
+    echo "  Copying VapourSynth files..."
+    # Copy vspipe
+    cp "$VS_INSTALL_DIR/bin/vspipe" "$DEPS_DIR/vapoursynth/vspipe-bin"
+    chmod +x "$DEPS_DIR/vapoursynth/vspipe-bin"
+
+    # Copy libraries
+    cp "$VS_INSTALL_DIR/lib/libvapoursynth.so"* "$DEPS_DIR/vapoursynth/"
+    cp "$VS_INSTALL_DIR/lib/libvapoursynth-script.so"* "$DEPS_DIR/vapoursynth/"
+
+    # Copy Python module
+    find "$VS_BUILD_DIR/build" -name "vapoursynth*.so" -exec cp {} "$PYTHON_PACKAGES_DIR/" \;
+
+    # Fix RPATHs
+    echo "  Fixing RPATHs..."
+    patchelf --set-rpath '$ORIGIN' "$DEPS_DIR/vapoursynth/vspipe-bin"
+    for lib in "$DEPS_DIR/vapoursynth"/libvapoursynth*.so*; do
+        [ -f "$lib" ] && [ ! -L "$lib" ] && patchelf --set-rpath '$ORIGIN:$ORIGIN/../python/lib' "$lib" 2>/dev/null || true
+    done
+    for so_file in "$PYTHON_PACKAGES_DIR"/vapoursynth*.so; do
+        [ -f "$so_file" ] && patchelf --set-rpath '$ORIGIN/../vapoursynth:$ORIGIN/../python/lib' "$so_file" 2>/dev/null || true
+    done
+
+    # Create wrapper script (same concept as macOS)
+    cat > "$DEPS_DIR/vapoursynth/vspipe" << 'WRAPPER_EOF'
+#!/bin/bash
+# VapourSynth vspipe wrapper - fully self-contained
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEPS_ROOT="$(dirname "$SCRIPT_DIR")"
+
+export PATH="$DEPS_ROOT/python/bin:$PATH"
+export PYTHONHOME="$DEPS_ROOT/python"
+export VAPOURSYNTH_PLUGIN_PATH="$SCRIPT_DIR/plugins"
+export PYTHONPATH="$DEPS_ROOT/python-packages:${PYTHONPATH:-}"
+export LD_LIBRARY_PATH="$SCRIPT_DIR:$DEPS_ROOT/python/lib:$DEPS_ROOT/lib:${LD_LIBRARY_PATH:-}"
+
+# Generate config dynamically with correct absolute path
+CONF_FILE=$(mktemp)
+cat > "$CONF_FILE" << EOF
+UserPluginDir=$SCRIPT_DIR/plugins
+AutoloadUserPluginDir=true
+AutoloadSystemPluginDir=false
+EOF
+export VAPOURSYNTH_CONF_PATH="$CONF_FILE"
+
+"$SCRIPT_DIR/vspipe-bin" "$@"
+EXIT_CODE=$?
+rm -f "$CONF_FILE"
+exit $EXIT_CODE
+WRAPPER_EOF
+    chmod +x "$DEPS_DIR/vapoursynth/vspipe"
+
+    # Copy VS headers to deps for plugin builds (persists across runs)
+    mkdir -p "$DEPS_DIR/vapoursynth/include"
+    cp "$VS_INSTALL_DIR/include/vapoursynth/"*.h "$DEPS_DIR/vapoursynth/include/"
+
+    cd "$BUILD_DIR"
+    echo "  Built VapourSynth from source with embedded Python"
+else
+    echo "  VapourSynth already built, skipping"
+fi
+
+# Set VS include dir for plugin builds (persisted in deps, survives temp dir cleanup)
+VS_INCLUDE_DIR="$DEPS_DIR/vapoursynth/include"
+
+# Create vapoursynth/ subdirectory symlinks for plugins that use #include <vapoursynth/VapourSynth.h>
+mkdir -p "$VS_INCLUDE_DIR/vapoursynth"
+for h in "$VS_INCLUDE_DIR"/*.h; do
+    [ -f "$h" ] && ln -sf "../$(basename "$h")" "$VS_INCLUDE_DIR/vapoursynth/$(basename "$h")" 2>/dev/null || true
+done
+
+# Make VapourSynth pkg-config available for plugin builds
+# Use the installed pkg-config files but patch the paths
+mkdir -p "$BUILD_DIR/pkgconfig"
+# Create pkg-config pointing to persisted headers and deps libs
+cat > "$BUILD_DIR/pkgconfig/vapoursynth.pc" << EOF
+prefix=$DEPS_DIR/vapoursynth
+libdir=\${prefix}
+includedir=\${prefix}/include
+
+Name: VapourSynth
+Description: VapourSynth
+Version: 73
+Libs: -L\${libdir} -lvapoursynth
+Cflags: -I\${includedir}
+EOF
+cp "$BUILD_DIR/pkgconfig/vapoursynth.pc" "$BUILD_DIR/pkgconfig/vapoursynth-script.pc"
+
+# ============================================================================
+# Download FFmpeg (static build)
+# ============================================================================
+echo ""
+echo "=== Downloading FFmpeg ==="
+
+if [ "$FORCE" = true ] || [ ! -f "$DEPS_DIR/ffmpeg/ffmpeg" ]; then
+    if [ "$ARCH" = "x86_64" ]; then
+        FFMPEG_URL="https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz"
+    else
+        FFMPEG_URL="https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-arm64-static.tar.xz"
+    fi
+
+    echo "  Downloading static FFmpeg..."
+    curl -L -o "$BUILD_DIR/ffmpeg.tar.xz" "$FFMPEG_URL"
+
+    echo "  Extracting..."
+    tar -xJf "$BUILD_DIR/ffmpeg.tar.xz" -C "$BUILD_DIR"
+    FFMPEG_DIR=$(find "$BUILD_DIR" -maxdepth 1 -name "ffmpeg-*-static" -type d | head -1)
+    if [ -z "$FFMPEG_DIR" ]; then
+        echo "  ERROR: Could not find extracted FFmpeg directory"
+        exit 1
+    fi
+
+    cp "$FFMPEG_DIR/ffmpeg" "$DEPS_DIR/ffmpeg/"
+    cp "$FFMPEG_DIR/ffprobe" "$DEPS_DIR/ffmpeg/"
+    chmod +x "$DEPS_DIR/ffmpeg/ffmpeg" "$DEPS_DIR/ffmpeg/ffprobe"
+    echo "  Downloaded FFmpeg"
+else
+    echo "  FFmpeg already exists, skipping"
+fi
+
+# ============================================================================
+# Copy FFTW3 (float, threads)
+# ============================================================================
+echo ""
+echo "=== Copying FFTW3 ==="
+
+LIB_DIR="$DEPS_DIR/lib"
+mkdir -p "$LIB_DIR"
+
+# Copy system FFTW if available
+FFTW_FOUND=false
+for libdir in /usr/lib/$ARCH-linux-gnu /usr/lib64 /usr/lib; do
+    if [ -f "$libdir/libfftw3f.so" ] || [ -f "$libdir/libfftw3f.so.3" ]; then
+        cp -L "$libdir/libfftw3f.so"* "$LIB_DIR/" 2>/dev/null || true
+        cp -L "$libdir/libfftw3f_threads.so"* "$LIB_DIR/" 2>/dev/null || true
+        FFTW_FOUND=true
+        echo "  Copied FFTW3 from $libdir"
+        break
+    fi
+done
+
+if [ "$FFTW_FOUND" = false ]; then
+    echo "  WARNING: FFTW3 not found. Some plugins may not work."
+    echo "  Install with: sudo apt install libfftw3-dev"
+fi
+
+# Fix FFTW RPATHs
+for lib in "$LIB_DIR"/libfftw3f*.so*; do
+    [ -f "$lib" ] && [ ! -L "$lib" ] && patchelf --set-rpath '$ORIGIN' "$lib" 2>/dev/null || true
+done
+
+# ============================================================================
+# Copy Boost libraries (filesystem, atomic — needed by some plugins)
+# ============================================================================
+echo ""
+echo "=== Copying Boost libraries ==="
+
+BOOST_FOUND=false
+for libdir in /usr/lib/$ARCH-linux-gnu /usr/lib64 /usr/lib; do
+    if [ -f "$libdir/libboost_filesystem.so" ] || ls "$libdir"/libboost_filesystem.so.* &>/dev/null; then
+        cp -L "$libdir/libboost_filesystem.so"* "$LIB_DIR/" 2>/dev/null || true
+        cp -L "$libdir/libboost_atomic.so"* "$LIB_DIR/" 2>/dev/null || true
+        BOOST_FOUND=true
+        echo "  Copied Boost from $libdir"
+        break
+    fi
+done
+
+if [ "$BOOST_FOUND" = false ]; then
+    echo "  WARNING: Boost not found (optional — needed by NNEDI3CL)"
+fi
+
+# Fix Boost RPATHs
+for lib in "$LIB_DIR"/libboost_*.so*; do
+    [ -f "$lib" ] && [ ! -L "$lib" ] && patchelf --set-rpath '$ORIGIN' "$lib" 2>/dev/null || true
+done
+
+# ============================================================================
+# Copy OpenCL ICD loader (thin library, loads vendor ICDs)
+# ============================================================================
+echo ""
+echo "=== Copying OpenCL ICD loader ==="
+
+OPENCL_FOUND=false
+for libdir in /usr/lib/$ARCH-linux-gnu /usr/lib64 /usr/lib; do
+    if [ -f "$libdir/libOpenCL.so.1" ] || [ -f "$libdir/libOpenCL.so" ]; then
+        cp -L "$libdir/libOpenCL.so"* "$LIB_DIR/" 2>/dev/null || true
+        OPENCL_FOUND=true
+        echo "  Copied OpenCL ICD loader from $libdir"
+        break
+    fi
+done
+
+if [ "$OPENCL_FOUND" = false ]; then
+    echo "  WARNING: OpenCL ICD loader not found (optional — GPU plugins degrade gracefully)"
+    echo "  Install with: sudo apt install ocl-icd-libopencl1"
+fi
+
+# ============================================================================
+# Build plugins from source
+# ============================================================================
+cd "$BUILD_DIR"
+
+BUILT_PLUGINS=()
+FAILED_PLUGINS=()
+
+# Patch meson.build files that use python3 to detect VS include path.
+# Some plugins run `python3 -c 'import vapoursynth; print(vs.get_include())'`
+# which fails with our bundled Python. Replace with hardcoded include path.
+patch_meson_vs_include() {
+    [ ! -f meson.build ] && return
+    python3 -c "
+import re
+with open('meson.build', 'r') as f:
+    content = f.read()
+content = re.sub(
+    r'incdir\s*=\s*include_directories\s*\(\s*run_command\s*\(.*?\)\.stdout\(\)\.strip\(\)\s*,?\s*\)',
+    \"incdir = include_directories('$VS_INCLUDE_DIR')\",
+    content,
+    flags=re.DOTALL
+)
+with open('meson.build', 'w') as f:
+    f.write(content)
+" 2>/dev/null || true
+}
+
+build_plugin() {
+    local name="$1"
+    local repo="$2"
+    local output_lib="$3"
+    local build_cmd="$4"
+
+    if [ "$FORCE" = false ] && [ -f "$PLUGINS_DIR/$output_lib" ]; then
+        echo "  $name already exists, skipping"
+        return 0
+    fi
+
+    echo ""
+    echo "=== Building $name ==="
+
+    rm -rf "$name"
+    if ! git clone --depth 1 "$repo" "$name" 2>/dev/null; then
+        echo "  Failed to clone $name"
+        FAILED_PLUGINS+=("$name")
+        return 1
+    fi
+
+    cd "$name"
+
+    # Patch meson.build if it uses python3 to detect VS include path
+    patch_meson_vs_include
+
+    if eval "$build_cmd"; then
+        local lib_path=$(find . -name "*.so" -type f 2>/dev/null | head -1)
+        if [ -n "$lib_path" ]; then
+            cp "$lib_path" "$PLUGINS_DIR/$output_lib"
+            # Fix RPATH for plugin
+            patchelf --set-rpath '$ORIGIN:$ORIGIN/../../lib' "$PLUGINS_DIR/$output_lib" 2>/dev/null || true
+            echo "  Built $name -> $output_lib"
+            BUILT_PLUGINS+=("$name")
+        else
+            echo "  Warning: No .so found for $name"
+            FAILED_PLUGINS+=("$name")
+        fi
+    else
+        echo "  Failed to build $name"
+        FAILED_PLUGINS+=("$name")
+    fi
+
+    cd "$BUILD_DIR"
+}
+
+# Common build environment for meson plugins
+PLUGIN_PKG_CONFIG="$BUILD_DIR/pkgconfig:$BUILD_PREFIX/lib/pkgconfig"
+PLUGIN_BUILD_ENV="PKG_CONFIG_PATH=$PLUGIN_PKG_CONFIG"
+
+# MVTools (essential for QTGMC motion compensation)
+build_plugin "mvtools" \
+    "https://github.com/dubhater/vapoursynth-mvtools.git" \
+    "libmvtools.so" \
+    "$PLUGIN_BUILD_ENV meson setup build --buildtype=release && ninja -C build"
+
+# ZNEDI3 (neural network interpolation - primary for QTGMC)
+echo ""
+echo "=== Building ZNEDI3 ==="
+if [ "$FORCE" = true ] || [ ! -f "$PLUGINS_DIR/libznedi3.so" ]; then
+    rm -rf znedi3
+    git clone --depth 1 --recursive https://github.com/sekrit-twc/znedi3.git znedi3
+    cd znedi3
+    ZNEDI3_OK=false
+    if [ "$ARCH" = "aarch64" ]; then
+        CXXFLAGS="-I$VS_INCLUDE_DIR -I$VS_INCLUDE_DIR" \
+        make X86=0 X86_AVX512=0 -j"$NPROC" 2>/dev/null && ZNEDI3_OK=true || \
+        { CXXFLAGS="-I$VS_INCLUDE_DIR -I$VS_INCLUDE_DIR" \
+        make -j"$NPROC" && ZNEDI3_OK=true; } || true
+    else
+        CXXFLAGS="-I$VS_INCLUDE_DIR -I$VS_INCLUDE_DIR" \
+        make -j"$NPROC" && ZNEDI3_OK=true || true
+    fi
+    if $ZNEDI3_OK; then
+        if [ -f "vsznedi3.so" ]; then
+            cp vsznedi3.so "$PLUGINS_DIR/libznedi3.so"
+        else
+            find . -name "*.so" | head -1 | xargs -I {} cp {} "$PLUGINS_DIR/libznedi3.so" 2>/dev/null || true
+        fi
+        [ -f "nnedi3_weights.bin" ] && cp nnedi3_weights.bin "$PLUGINS_DIR/"
+        patchelf --set-rpath '$ORIGIN:$ORIGIN/../../lib' "$PLUGINS_DIR/libznedi3.so" 2>/dev/null || true
+        BUILT_PLUGINS+=("znedi3")
+        echo "  Built ZNEDI3"
+    else
+        echo "  Failed to build ZNEDI3"
+        FAILED_PLUGINS+=("znedi3")
+    fi
+    cd "$BUILD_DIR"
+else
+    echo "  ZNEDI3 already exists, skipping"
+fi
+
+# NNEDI3 (CPU version)
+echo ""
+echo "=== Building NNEDI3 ==="
+if [ "$FORCE" = true ] || [ ! -f "$PLUGINS_DIR/libnnedi3.so" ]; then
+    rm -rf nnedi3
+    git clone --depth 1 https://github.com/dubhater/vapoursynth-nnedi3.git nnedi3
+    cd nnedi3
+    if ./autogen.sh && \
+       PKG_CONFIG_PATH="$PLUGIN_PKG_CONFIG" \
+       CFLAGS="-I$VS_INCLUDE_DIR" \
+       CXXFLAGS="-I$VS_INCLUDE_DIR" \
+       ./configure && \
+       make -j"$NPROC"; then
+        find . -name "libnnedi3.so" | head -1 | xargs -I {} cp {} "$PLUGINS_DIR/libnnedi3.so" 2>/dev/null || \
+            find . -name "*.so" | head -1 | xargs -I {} cp {} "$PLUGINS_DIR/libnnedi3.so" 2>/dev/null
+        patchelf --set-rpath '$ORIGIN:$ORIGIN/../../lib' "$PLUGINS_DIR/libnnedi3.so" 2>/dev/null || true
+        BUILT_PLUGINS+=("nnedi3")
+        echo "  Built NNEDI3"
+    else
+        echo "  Failed to build NNEDI3 (may not support this architecture)"
+        FAILED_PLUGINS+=("nnedi3")
+    fi
+    cd "$BUILD_DIR"
+else
+    echo "  NNEDI3 already exists, skipping"
+fi
+
+# NNEDI3CL (OpenCL version)
+build_plugin "nnedi3cl" \
+    "https://github.com/HomeOfVapourSynthEvolution/VapourSynth-NNEDI3CL.git" \
+    "libnnedi3cl.so" \
+    "$PLUGIN_BUILD_ENV meson setup build --buildtype=release && ninja -C build"
+
+# EEDI3m (edge-directed interpolation)
+build_plugin "eedi3m" \
+    "https://github.com/HomeOfVapourSynthEvolution/VapourSynth-EEDI3.git" \
+    "libeedi3m.so" \
+    "$PLUGIN_BUILD_ENV meson setup build --buildtype=release && ninja -C build"
+
+# fmtconv (format conversion)
+echo ""
+echo "=== Building fmtconv ==="
+if [ "$FORCE" = true ] || [ ! -f "$PLUGINS_DIR/libfmtconv.so" ]; then
+    rm -rf fmtconv
+    git clone --depth 1 https://github.com/EleonoreMizo/fmtconv.git fmtconv
+    cd fmtconv/build/unix
+    if ./autogen.sh && \
+       PKG_CONFIG_PATH="$PLUGIN_PKG_CONFIG" \
+       CXXFLAGS="-I$VS_INCLUDE_DIR" \
+       ./configure && \
+       make -j"$NPROC"; then
+        find ../.. -name "libfmtconv*.so" | head -1 | xargs -I {} cp {} "$PLUGINS_DIR/libfmtconv.so" 2>/dev/null || \
+            cp .libs/libfmtconv.so "$PLUGINS_DIR/" 2>/dev/null
+        patchelf --set-rpath '$ORIGIN:$ORIGIN/../../lib' "$PLUGINS_DIR/libfmtconv.so" 2>/dev/null || true
+        BUILT_PLUGINS+=("fmtconv")
+        echo "  Built fmtconv"
+    else
+        echo "  Failed to build fmtconv"
+        FAILED_PLUGINS+=("fmtconv")
+    fi
+    cd "$BUILD_DIR"
+else
+    echo "  fmtconv already exists, skipping"
+fi
+
+# DFTTest (FFT-based denoising)
+build_plugin "dfttest" \
+    "https://github.com/HomeOfVapourSynthEvolution/VapourSynth-DFTTest.git" \
+    "libdfttest.so" \
+    "$PLUGIN_BUILD_ENV meson setup build --buildtype=release && ninja -C build"
+
+# FFT3DFilter
+build_plugin "fft3dfilter" \
+    "https://github.com/myrsloik/VapourSynth-FFT3DFilter.git" \
+    "libfft3dfilter.so" \
+    "$PLUGIN_BUILD_ENV meson setup build --buildtype=release && ninja -C build"
+
+# MiscFilters
+build_plugin "miscfilters" \
+    "https://github.com/vapoursynth/vs-miscfilters-obsolete.git" \
+    "libmiscfilters.so" \
+    "$PLUGIN_BUILD_ENV meson setup build --buildtype=release && ninja -C build"
+
+# RemoveGrain
+build_plugin "removegrain" \
+    "https://github.com/vapoursynth/vs-removegrain.git" \
+    "libremovegrain.so" \
+    "$PLUGIN_BUILD_ENV meson setup build --buildtype=release && ninja -C build"
+
+# AddGrain
+build_plugin "addgrain" \
+    "https://github.com/HomeOfVapourSynthEvolution/VapourSynth-AddGrain.git" \
+    "libaddgrain.so" \
+    "$PLUGIN_BUILD_ENV meson setup build --buildtype=release && ninja -C build"
+
+# VIVTC (inverse telecine - VFM + VDecimate)
+build_plugin "vivtc" \
+    "https://github.com/vapoursynth/vivtc.git" \
+    "libvivtc.so" \
+    "$PLUGIN_BUILD_ENV meson setup build --buildtype=release && ninja -C build"
+
+# neo-f3kdb (debanding)
+echo ""
+echo "=== Building neo-f3kdb ==="
+if [ "$FORCE" = true ] || [ ! -f "$PLUGINS_DIR/libneo-f3kdb.so" ]; then
+    rm -rf f3kdb
+    git clone --depth 1 https://github.com/HomeOfAviSynthPlusEvolution/neo_f3kdb.git f3kdb
+    cd f3kdb
+    # Remove TBB dependency (not always available, optional for threading)
+    sed -i 's/target_link_libraries.*tbb.*//' CMakeLists.txt 2>/dev/null || true
+    if cmake -B build -S . -DCMAKE_BUILD_TYPE=Release && \
+       cmake --build build --config Release -j"$NPROC"; then
+        find build -name "*.so" | head -1 | xargs -I {} cp {} "$PLUGINS_DIR/libneo-f3kdb.so"
+        patchelf --set-rpath '$ORIGIN:$ORIGIN/../../lib' "$PLUGINS_DIR/libneo-f3kdb.so" 2>/dev/null || true
+        BUILT_PLUGINS+=("neo-f3kdb")
+        echo "  Built neo-f3kdb"
+    else
+        echo "  Failed to build neo-f3kdb"
+        FAILED_PLUGINS+=("neo-f3kdb")
+    fi
+    cd "$BUILD_DIR"
+else
+    echo "  neo-f3kdb already exists, skipping"
+fi
+
+# CAS (Contrast Adaptive Sharpening)
+build_plugin "cas" \
+    "https://github.com/HomeOfVapourSynthEvolution/VapourSynth-CAS.git" \
+    "libcas.so" \
+    "$PLUGIN_BUILD_ENV meson setup build --buildtype=release && ninja -C build"
+
+# DCTFilter
+build_plugin "dctfilter" \
+    "https://github.com/HomeOfVapourSynthEvolution/VapourSynth-DCTFilter.git" \
+    "libdctfilter.so" \
+    "$PLUGIN_BUILD_ENV meson setup build --buildtype=release && ninja -C build"
+
+# Deblock
+build_plugin "deblock" \
+    "https://github.com/HomeOfVapourSynthEvolution/VapourSynth-Deblock.git" \
+    "libdeblock.so" \
+    "$PLUGIN_BUILD_ENV meson setup build --buildtype=release && ninja -C build"
+
+# AWarpSharp2
+build_plugin "awarpsharp2" \
+    "https://github.com/dubhater/vapoursynth-awarpsharp2.git" \
+    "libawarpsharp2.so" \
+    "$PLUGIN_BUILD_ENV meson setup build --buildtype=release && ninja -C build"
+
+# CTMF (Constant Time Median Filter)
+build_plugin "ctmf" \
+    "https://github.com/HomeOfVapourSynthEvolution/VapourSynth-CTMF.git" \
+    "libctmf.so" \
+    "$PLUGIN_BUILD_ENV meson setup build --buildtype=release && ninja -C build"
+
+# TCanny (edge detection)
+build_plugin "tcanny" \
+    "https://github.com/HomeOfVapourSynthEvolution/VapourSynth-TCanny.git" \
+    "libtcanny.so" \
+    "$PLUGIN_BUILD_ENV meson setup build --buildtype=release && ninja -C build"
+
+# BM3D
+build_plugin "bm3d" \
+    "https://github.com/HomeOfVapourSynthEvolution/VapourSynth-BM3D.git" \
+    "libbm3d.so" \
+    "$PLUGIN_BUILD_ENV meson setup build --buildtype=release && ninja -C build"
+
+# KNLMeansCL (OpenCL denoiser)
+build_plugin "knlmeanscl" \
+    "https://github.com/Khanattila/KNLMeansCL.git" \
+    "libknlmeanscl.so" \
+    "$PLUGIN_BUILD_ENV meson setup build --buildtype=release && ninja -C build"
+
+# ============================================================================
+# Download NNEDI3 weights
+# ============================================================================
+echo ""
+echo "=== Downloading NNEDI3 weights ==="
+if [ ! -f "$PLUGINS_DIR/nnedi3_weights.bin" ]; then
+    curl -L -o "$PLUGINS_DIR/nnedi3_weights.bin" \
+        "https://github.com/sekrit-twc/znedi3/raw/master/nnedi3_weights.bin"
+    echo "  Downloaded nnedi3_weights.bin"
+fi
+cp "$PLUGINS_DIR/nnedi3_weights.bin" "$DEPS_DIR/resources/NNEDI3CL/" 2>/dev/null || true
+
+# ============================================================================
+# Download Python packages
+# ============================================================================
+echo ""
+echo "=== Downloading Python packages ==="
+
+# havsfunc
+HAVSFUNC_URL="https://github.com/HomeOfVapourSynthEvolution/havsfunc/archive/refs/tags/r31.tar.gz"
+if [ "$FORCE" = true ] || [ ! -f "$PYTHON_PACKAGES_DIR/havsfunc.py" ]; then
+    curl -L -o /tmp/havsfunc.tar.gz "$HAVSFUNC_URL"
+    tar -xzf /tmp/havsfunc.tar.gz -C /tmp
+    cp /tmp/havsfunc-r31/havsfunc.py "$PYTHON_PACKAGES_DIR/"
+    rm -rf /tmp/havsfunc.tar.gz /tmp/havsfunc-r31
+    echo "  Downloaded havsfunc.py"
+fi
+
+# mvsfunc
+if [ "$FORCE" = true ] || [ ! -d "$PYTHON_PACKAGES_DIR/mvsfunc" ]; then
+    curl -L -o /tmp/mvsfunc.zip "https://github.com/HomeOfVapourSynthEvolution/mvsfunc/archive/refs/heads/master.zip"
+    unzip -q /tmp/mvsfunc.zip -d /tmp
+    cp -r /tmp/mvsfunc-master/mvsfunc "$PYTHON_PACKAGES_DIR/"
+    rm -rf /tmp/mvsfunc.zip /tmp/mvsfunc-master
+    echo "  Downloaded mvsfunc"
+fi
+
+# adjust
+if [ "$FORCE" = true ] || [ ! -f "$PYTHON_PACKAGES_DIR/adjust.py" ]; then
+    curl -L -o "$PYTHON_PACKAGES_DIR/adjust.py" \
+        "https://raw.githubusercontent.com/dubhater/vapoursynth-adjust/master/adjust.py" 2>/dev/null || true
+    echo "  Downloaded adjust.py"
+fi
+
+# ============================================================================
+# Patch havsfunc for API compatibility
+# ============================================================================
+echo ""
+echo "=== Patching havsfunc ==="
+
+HAVSFUNC="$PYTHON_PACKAGES_DIR/havsfunc.py"
+if [ -f "$HAVSFUNC" ]; then
+    HAVSFUNC_PATH="$HAVSFUNC" python3 << 'PYEOF'
+import re
+import sys
+import os
+
+havsfunc_path = os.environ.get('HAVSFUNC_PATH', '')
+if not havsfunc_path:
+    print("  Error: HAVSFUNC_PATH not set")
+    sys.exit(1)
+
+with open(havsfunc_path, 'r') as f:
+    content = f.read()
+
+patches = []
+
+# Patch 1: mvtools API
+if '_fix_mv_args' not in content:
+    patch_func = '''
+
+# Compatibility patch for mvtools API
+def _fix_mv_args(args):
+    result = {}
+    for k, v in args.items():
+        if k == '_lambda':
+            result['lambda'] = v
+        elif k == '_global':
+            result['global'] = v
+        else:
+            result[k] = v
+    return result
+'''
+    content = content.replace('import math\n', 'import math\n' + patch_func)
+    content = content.replace('**analyse_args)', '**_fix_mv_args(analyse_args))')
+    content = content.replace('**recalculate_args)', '**_fix_mv_args(recalculate_args))')
+    patches.append('mvtools API')
+
+# Patch 2: DFTTest API
+if "sstring='0.0:4.0 0.2:9.0 1.0:15.0'" in content:
+    content = content.replace("sstring='0.0:4.0 0.2:9.0 1.0:15.0'", "sigma=10.0")
+    patches.append('DFTTest API')
+
+# Patch 3: YCOCG removal
+if 'vs.YCOCG' in content:
+    content = content.replace(
+        "input.format.color_family not in [vs.YUV, vs.YCOCG]",
+        "input.format.color_family != vs.YUV"
+    )
+    content = content.replace(
+        "'LUTDeCrawl: This is not an 8-10 bit YUV or YCoCg clip'",
+        "'LUTDeCrawl: This is not an 8-10 bit YUV clip'"
+    )
+    patches.append('YCOCG')
+
+# Patch 4: EEDI3CL fallback
+patched_eedi3cl = False
+old_santiag = "            myEEDI3 = core.eedi3m.EEDI3CL\n"
+if old_santiag in content:
+    content = content.replace(
+        old_santiag,
+        "            has_eedi3cl = hasattr(core, 'eedi3m') and hasattr(core.eedi3m, 'EEDI3CL')\n"
+        "            myEEDI3 = core.eedi3m.EEDI3CL if has_eedi3cl else (core.eedi3m.EEDI3 if hasattr(core, 'eedi3m') else core.eedi3.eedi3)\n"
+    )
+    old_santiag_args = "            eedi3_args = dict(alpha=alpha, beta=beta, gamma=gamma, nrad=nrad, mdis=mdis, vcheck=vcheck, device=device)\n"
+    new_santiag_args = "            eedi3_args = dict(alpha=alpha, beta=beta, gamma=gamma, nrad=nrad, mdis=mdis, vcheck=vcheck, device=device) if has_eedi3cl else dict(alpha=alpha, beta=beta, gamma=gamma, nrad=nrad, mdis=mdis, vcheck=vcheck)\n"
+    content = content.replace(old_santiag_args, new_santiag_args)
+    patched_eedi3cl = True
+
+old_qtgmc = "        myEEDI3 = core.eedi3m.EEDI3CL\n"
+if old_qtgmc in content:
+    content = content.replace(
+        old_qtgmc,
+        "        has_eedi3cl = hasattr(core, 'eedi3m') and hasattr(core.eedi3m, 'EEDI3CL')\n"
+        "        myEEDI3 = core.eedi3m.EEDI3CL if has_eedi3cl else (core.eedi3m.EEDI3 if hasattr(core, 'eedi3m') else core.eedi3.eedi3)\n"
+    )
+    old_qtgmc_args = "        eedi3_args = dict(alpha=alpha, beta=beta, gamma=gamma, nrad=nrad, mdis=EdiMaxD, vcheck=vcheck, device=device)\n"
+    new_qtgmc_args = "        eedi3_args = dict(alpha=alpha, beta=beta, gamma=gamma, nrad=nrad, mdis=EdiMaxD, vcheck=vcheck, device=device) if has_eedi3cl else dict(alpha=alpha, beta=beta, gamma=gamma, nrad=nrad, mdis=EdiMaxD, vcheck=vcheck)\n"
+    content = content.replace(old_qtgmc_args, new_qtgmc_args)
+    patched_eedi3cl = True
+
+if patched_eedi3cl:
+    patches.append('EEDI3CL fallback')
+
+if patches:
+    with open(havsfunc_path, 'w') as f:
+        f.write(content)
+    print(f"  Patched: {', '.join(patches)}")
+else:
+    print("  Already patched")
+PYEOF
+fi
+
+# ============================================================================
+# Copy libdvdread
+# ============================================================================
+echo ""
+echo "=== Copying libdvdread ==="
+
+DVDREAD_FOUND=false
+for libdir in /usr/lib/$ARCH-linux-gnu /usr/lib64 /usr/lib /usr/local/lib; do
+    if [ -f "$libdir/libdvdread.so" ] || ls "$libdir"/libdvdread.so.* &>/dev/null; then
+        cp -L "$libdir/libdvdread.so"* "$LIB_DIR/" 2>/dev/null || true
+        # Ensure there's a libdvdread.so symlink
+        if [ ! -f "$LIB_DIR/libdvdread.so" ]; then
+            DVDREAD_VERSIONED=$(ls "$LIB_DIR"/libdvdread.so.* 2>/dev/null | head -1)
+            [ -n "$DVDREAD_VERSIONED" ] && ln -sf "$(basename "$DVDREAD_VERSIONED")" "$LIB_DIR/libdvdread.so"
+        fi
+        DVDREAD_FOUND=true
+        echo "  Copied libdvdread from $libdir"
+        break
+    fi
+done
+
+if [ "$DVDREAD_FOUND" = false ]; then
+    echo "  WARNING: libdvdread not found (optional — needed for DVD extraction)"
+    echo "  Install with: sudo apt install libdvdread-dev"
+fi
+
+for lib in "$LIB_DIR"/libdvdread*.so*; do
+    [ -f "$lib" ] && [ ! -L "$lib" ] && patchelf --set-rpath '$ORIGIN' "$lib" 2>/dev/null || true
+done
+
+# ============================================================================
+# Final RPATH verification
+# ============================================================================
+echo ""
+echo "=== Verifying RPATHs ==="
+
+RPATH_ISSUES=0
+for so_file in $(find "$DEPS_DIR" -name "*.so" -o -name "*.so.*" | grep -v __pycache__); do
+    [ -L "$so_file" ] && continue
+    MISSING=$(ldd "$so_file" 2>/dev/null | grep "not found" || true)
+    if [ -n "$MISSING" ]; then
+        echo "  WARNING: $(basename "$so_file") has missing deps:"
+        echo "    $MISSING"
+        RPATH_ISSUES=$((RPATH_ISSUES + 1))
+    fi
+done
+
+if [ "$RPATH_ISSUES" -eq 0 ]; then
+    echo "  All RPATHs OK"
+fi
+
+# ============================================================================
+# Write version file
+# ============================================================================
+echo ""
+echo "=== Writing version file ==="
+
+cat > "$DEPS_DIR/version.json" << EOF
+{
+  "version": "1.0.0",
+  "installedAt": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+  "platform": "$PLATFORM_DIR",
+  "architecture": "$ARCH",
+  "buildType": "source"
+}
+EOF
+
+# ============================================================================
+# Cleanup
+# ============================================================================
+echo ""
+echo "=== Cleaning up ==="
+rm -rf "$BUILD_DIR"
+
+# ============================================================================
+# Verify installation
+# ============================================================================
+echo ""
+echo "=== Verification ==="
+
+echo "Plugin architectures:"
+for plugin in "$PLUGINS_DIR"/*.so; do
+    if [ -f "$plugin" ]; then
+        arch=$(file "$plugin" | grep -oE '(x86-64|aarch64|x86_64|ARM aarch64)' | head -1)
+        name=$(basename "$plugin")
+        echo "  $name: $arch"
+    fi
+done
+
+echo ""
+echo "vspipe:"
+file "$DEPS_DIR/vapoursynth/vspipe-bin"
+
+echo ""
+echo "=== Summary ==="
+PLUGIN_COUNT=$(ls -1 "$PLUGINS_DIR"/*.so 2>/dev/null | wc -l | tr -d ' ')
+echo "Total plugins: $PLUGIN_COUNT"
+
+if [ ${#FAILED_PLUGINS[@]} -gt 0 ]; then
+    echo ""
+    echo "Failed plugins: ${FAILED_PLUGINS[*]}"
+fi
+
+echo ""
+echo "Installation complete: $DEPS_DIR"
+echo ""
+echo "To test:"
+echo "  LD_LIBRARY_PATH='$DEPS_DIR/vapoursynth:$DEPS_DIR/python/lib:$DEPS_DIR/lib' \\"
+echo "  VAPOURSYNTH_PLUGIN_PATH='$PLUGINS_DIR' \\"
+echo "  PYTHONPATH='$PYTHON_PACKAGES_DIR' \\"
+echo "  '$DEPS_DIR/vapoursynth/vspipe' --version"

--- a/Scripts/package-deps-linux.sh
+++ b/Scripts/package-deps-linux.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+# Package VapourBox Dependencies for Linux
+# Creates standalone dependency zip files for x64 and arm64
+#
+# Prerequisites:
+# - Dependencies downloaded (run download-deps-linux.sh first)
+#
+# Usage: ./Scripts/package-deps-linux.sh --version 1.0.0 [--arch x64|arm64|both]
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+DIST_DIR="$PROJECT_ROOT/dist"
+
+VERSION=""
+ARCH="both"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --version)
+            VERSION="$2"
+            shift 2
+            ;;
+        --arch)
+            ARCH="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "ERROR: --version is required" >&2
+    echo "Usage: $0 --version 1.0.0 [--arch x64|arm64|both]" >&2
+    exit 1
+fi
+
+echo "=== Packaging VapourBox Dependencies for Linux ==="
+echo "Version: $VERSION"
+echo "Architecture: $ARCH"
+echo ""
+
+mkdir -p "$DIST_DIR"
+
+package_arch() {
+    local ARCH_NAME=$1
+    local DEPS_DIR="$PROJECT_ROOT/deps/linux-$ARCH_NAME"
+    local PACKAGE_NAME="VapourBox-deps-$VERSION-linux-$ARCH_NAME"
+    local PACKAGE_DIR="$DIST_DIR/$PACKAGE_NAME"
+
+    echo "[1/4] Checking prerequisites for $ARCH_NAME..."
+
+    if [ ! -d "$DEPS_DIR" ]; then
+        echo "WARNING: Dependencies not found at $DEPS_DIR"
+        echo "Run './Scripts/download-deps-linux.sh' first"
+        return 1
+    fi
+
+    if [ ! -f "$DEPS_DIR/ffmpeg/ffmpeg" ]; then
+        echo "WARNING: FFmpeg not found for $ARCH_NAME"
+        return 1
+    fi
+
+    echo "    Prerequisites OK for $ARCH_NAME"
+
+    echo "[2/4] Creating package structure for $ARCH_NAME..."
+    rm -rf "$PACKAGE_DIR"
+    mkdir -p "$PACKAGE_DIR/ffmpeg"
+    mkdir -p "$PACKAGE_DIR/vapoursynth/plugins"
+    mkdir -p "$PACKAGE_DIR/lib"
+    mkdir -p "$PACKAGE_DIR/python-packages"
+    mkdir -p "$PACKAGE_DIR/python"
+    mkdir -p "$PACKAGE_DIR/resources/NNEDI3CL"
+
+    echo "[3/4] Copying dependencies for $ARCH_NAME..."
+
+    # Copy FFmpeg
+    echo "    Copying FFmpeg..."
+    cp "$DEPS_DIR/ffmpeg/ffmpeg" "$PACKAGE_DIR/ffmpeg/"
+    [ -f "$DEPS_DIR/ffmpeg/ffprobe" ] && cp "$DEPS_DIR/ffmpeg/ffprobe" "$PACKAGE_DIR/ffmpeg/"
+
+    # Copy VapourSynth
+    echo "    Copying VapourSynth..."
+    if [ -d "$DEPS_DIR/vapoursynth" ]; then
+        cp -r "$DEPS_DIR/vapoursynth/"* "$PACKAGE_DIR/vapoursynth/"
+    fi
+
+    # Copy support libraries (fftw, boost, opencl, dvdread, etc.)
+    echo "    Copying support libraries..."
+    if [ -d "$DEPS_DIR/lib" ]; then
+        cp -r "$DEPS_DIR/lib/"* "$PACKAGE_DIR/lib/" 2>/dev/null || true
+    fi
+
+    # Copy Python runtime
+    echo "    Copying Python..."
+    if [ -d "$DEPS_DIR/python" ]; then
+        cp -r "$DEPS_DIR/python/"* "$PACKAGE_DIR/python/"
+    fi
+
+    # Copy Python packages
+    echo "    Copying Python packages..."
+    if [ -d "$DEPS_DIR/python-packages" ]; then
+        cp -r "$DEPS_DIR/python-packages/"* "$PACKAGE_DIR/python-packages/"
+    fi
+
+    # Copy NNEDI3 weights if present
+    if [ -d "$DEPS_DIR/resources/NNEDI3CL" ]; then
+        cp -r "$DEPS_DIR/resources/NNEDI3CL/"* "$PACKAGE_DIR/resources/NNEDI3CL/" 2>/dev/null || true
+    fi
+
+    # Create version file
+    echo "    Creating version file..."
+    cat > "$PACKAGE_DIR/version.json" << EOF
+{
+  "version": "$VERSION",
+  "installedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+
+    # Remove unnecessary files
+    echo "    Cleaning up..."
+    find "$PACKAGE_DIR" -name "__pycache__" -type d -exec rm -rf {} + 2>/dev/null || true
+    find "$PACKAGE_DIR" -name "*.pyc" -delete 2>/dev/null || true
+    find "$PACKAGE_DIR" -name "*.auto.conf" -delete 2>/dev/null || true
+
+    echo "[4/4] Creating zip archive for $ARCH_NAME..."
+    local ZIP_FILE="$DIST_DIR/$PACKAGE_NAME.zip"
+    rm -f "$ZIP_FILE"
+    # Zip contents without wrapper directory (so extraction is flat)
+    cd "$PACKAGE_DIR"
+    zip -r -q "$ZIP_FILE" .
+
+    # Calculate size and hash
+    local ZIP_SIZE=$(stat -c%s "$ZIP_FILE" 2>/dev/null || stat -f%z "$ZIP_FILE" 2>/dev/null)
+    local ZIP_SIZE_MB=$(echo "scale=1; $ZIP_SIZE / 1048576" | bc)
+    local SHA256=$(sha256sum "$ZIP_FILE" | cut -d' ' -f1)
+
+    echo ""
+    echo "=== $ARCH_NAME Package Complete ==="
+    echo "Zip file: $ZIP_FILE"
+    echo "Size: ${ZIP_SIZE_MB} MB"
+    echo "SHA256: $SHA256"
+    echo ""
+
+    # Cleanup
+    rm -rf "$PACKAGE_DIR"
+
+    # Output JSON snippet
+    echo "Update deps-version.json with:"
+    echo "  \"linux-$ARCH_NAME\": {"
+    echo "    \"filename\": \"$PACKAGE_NAME.zip\","
+    echo "    \"sha256\": \"$SHA256\","
+    echo "    \"size\": $ZIP_SIZE"
+    echo "  }"
+    echo ""
+}
+
+# Package requested architectures
+case "$ARCH" in
+    x64)
+        package_arch "x64"
+        ;;
+    arm64)
+        package_arch "arm64"
+        ;;
+    both)
+        echo "Packaging both architectures..."
+        echo ""
+        package_arch "x64" || echo "WARNING: x64 packaging failed"
+        echo ""
+        package_arch "arm64" || echo "WARNING: arm64 packaging failed"
+        ;;
+    *)
+        echo "ERROR: Invalid architecture: $ARCH" >&2
+        echo "Use: x64, arm64, or both" >&2
+        exit 1
+        ;;
+esac
+
+echo "Done. Upload zip files to GitHub release deps-v$VERSION"

--- a/Scripts/package-linux.sh
+++ b/Scripts/package-linux.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# Package VapourBox for Linux
+# Creates a distributable tarball with Flutter app + Rust worker + templates
+#
+# Prerequisites:
+# - Flutter SDK, Rust toolchain
+# - Worker and app already built (or use without --skip-build)
+#
+# Usage: ./Scripts/package-linux.sh --version X.Y.Z [--skip-build] [--arch x64|arm64]
+
+set -e
+
+VERSION="1.0.0"
+SKIP_BUILD=false
+ARCH=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --version) VERSION="$2"; shift 2 ;;
+        --skip-build) SKIP_BUILD=true; shift ;;
+        --arch) ARCH="$2"; shift 2 ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: $0 --version X.Y.Z [--skip-build] [--arch x64|arm64]"
+            exit 1
+            ;;
+    esac
+done
+
+# Detect architecture if not specified
+if [ -z "$ARCH" ]; then
+    if [ "$(uname -m)" = "aarch64" ]; then
+        ARCH="arm64"
+    else
+        ARCH="x64"
+    fi
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+DIST_DIR="$PROJECT_ROOT/dist"
+PACKAGE_NAME="VapourBox-$VERSION-linux-$ARCH"
+PACKAGE_DIR="$DIST_DIR/$PACKAGE_NAME"
+
+echo "=== Packaging VapourBox for Linux ($ARCH) ==="
+echo "Version: $VERSION"
+echo ""
+
+STEP=1
+TOTAL_STEPS=4
+if ! $SKIP_BUILD; then
+    TOTAL_STEPS=5
+fi
+
+# Build if needed
+if ! $SKIP_BUILD; then
+    echo "[$STEP/$TOTAL_STEPS] Building Rust worker..."
+    cd "$PROJECT_ROOT/worker"
+    cargo build --release
+    STEP=$((STEP + 1))
+
+    echo "[$STEP/$TOTAL_STEPS] Building Flutter app..."
+    cd "$PROJECT_ROOT/app"
+    flutter pub get
+    dart run build_runner build --delete-conflicting-outputs
+    flutter build linux --release
+    STEP=$((STEP + 1))
+else
+    echo "[$STEP/$TOTAL_STEPS] Skipping build (--skip-build)"
+    STEP=$((STEP + 1))
+fi
+
+# Determine Flutter build output directory
+if [ "$ARCH" = "arm64" ]; then
+    FLUTTER_BUNDLE="$PROJECT_ROOT/app/build/linux/arm64/release/bundle"
+else
+    FLUTTER_BUNDLE="$PROJECT_ROOT/app/build/linux/x64/release/bundle"
+fi
+
+if [ ! -d "$FLUTTER_BUNDLE" ]; then
+    echo "ERROR: Flutter build output not found at $FLUTTER_BUNDLE"
+    echo "Build the app first or check architecture."
+    exit 1
+fi
+
+# Create package structure
+echo "[$STEP/$TOTAL_STEPS] Creating package structure..."
+rm -rf "$PACKAGE_DIR"
+mkdir -p "$PACKAGE_DIR"
+mkdir -p "$DIST_DIR"
+
+# Copy Flutter build output (executable, lib/, data/)
+cp -r "$FLUTTER_BUNDLE/"* "$PACKAGE_DIR/"
+
+STEP=$((STEP + 1))
+
+# Copy Rust worker
+echo "[$STEP/$TOTAL_STEPS] Copying worker and templates..."
+WORKER_BIN="$PROJECT_ROOT/worker/target/release/vapourbox-worker"
+if [ ! -f "$WORKER_BIN" ]; then
+    echo "ERROR: Worker executable not found at $WORKER_BIN"
+    exit 1
+fi
+cp "$WORKER_BIN" "$PACKAGE_DIR/"
+chmod +x "$PACKAGE_DIR/vapourbox-worker"
+
+# Copy VapourSynth templates
+mkdir -p "$PACKAGE_DIR/templates"
+cp "$PROJECT_ROOT/worker/templates/"*.vpy "$PACKAGE_DIR/templates/"
+cp "$PROJECT_ROOT/worker/templates/pipe_source.py" "$PACKAGE_DIR/templates/"
+cp "$PROJECT_ROOT/worker/templates/spotless.py" "$PACKAGE_DIR/templates/"
+
+# Copy licenses
+mkdir -p "$PACKAGE_DIR/licenses"
+cp -r "$PROJECT_ROOT/licenses/"* "$PACKAGE_DIR/licenses/" 2>/dev/null || true
+[ -f "$PROJECT_ROOT/LICENSE" ] && cp "$PROJECT_ROOT/LICENSE" "$PACKAGE_DIR/"
+
+STEP=$((STEP + 1))
+
+# Create tarball
+echo "[$STEP/$TOTAL_STEPS] Creating tarball..."
+cd "$DIST_DIR"
+TAR_FILE="$PACKAGE_NAME.tar.gz"
+tar -czf "$TAR_FILE" "$PACKAGE_NAME"
+
+# Calculate size and hash
+TAR_SIZE=$(stat -c%s "$TAR_FILE" 2>/dev/null || stat -f%z "$TAR_FILE" 2>/dev/null)
+TAR_SIZE_MB=$(echo "scale=1; $TAR_SIZE / 1048576" | bc)
+SHA256=$(sha256sum "$TAR_FILE" 2>/dev/null | cut -d' ' -f1 || shasum -a 256 "$TAR_FILE" | cut -d' ' -f1)
+
+# Cleanup unpacked directory
+rm -rf "$PACKAGE_DIR"
+
+echo ""
+echo "=== Packaging Complete ==="
+echo ""
+echo "  Tarball: $DIST_DIR/$TAR_FILE"
+echo "  Size:    ${TAR_SIZE_MB} MB"
+echo "  SHA256:  $SHA256"
+echo ""
+echo "To install:"
+echo "  tar -xzf $TAR_FILE"
+echo "  cd $PACKAGE_NAME"
+echo "  ./vapourbox"
+echo ""
+echo "Note: Dependencies will be downloaded on first launch."

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -230,6 +230,11 @@ EOF
         echo "Created: dist/VapourBox-deps-$DEPS_VERSION-windows-x64.zip"
     fi
 
+    # Package Linux deps (if deps exist)
+    if [ -d "$PROJECT_ROOT/deps/linux-x64" ] || [ -d "$PROJECT_ROOT/deps/linux-arm64" ]; then
+        "$SCRIPT_DIR/package-deps-linux.sh" --version "$DEPS_VERSION" --arch both || true
+    fi
+
     echo ""
     echo -e "${BLUE}[2/6] Creating deps release on GitHub...${NC}"
 
@@ -285,7 +290,7 @@ else
 fi
 
 echo ""
-echo -e "${BLUE}[5/6] Triggering Windows build...${NC}"
+echo -e "${BLUE}[5/6] Triggering Windows and Linux builds...${NC}"
 
 # Check if GitHub Actions workflow exists
 if [ -f "$PROJECT_ROOT/.github/workflows/build-windows.yml" ]; then
@@ -300,6 +305,18 @@ if [ -f "$PROJECT_ROOT/.github/workflows/build-windows.yml" ]; then
 else
     echo -e "${YELLOW}No Windows build workflow found at .github/workflows/build-windows.yml${NC}"
     echo -e "${YELLOW}Build Windows manually using: ./Scripts/package-windows.ps1 -Version $APP_VERSION${NC}"
+fi
+
+if [ -f "$PROJECT_ROOT/.github/workflows/build-linux.yml" ]; then
+    echo "Triggering GitHub Actions workflow for Linux build..."
+    gh workflow run build-linux.yml \
+        --repo "$GITHUB_REPO" \
+        --ref "main" \
+        -f version="$APP_VERSION" \
+        -f deps_tag="$DEPS_TAG" \
+        -f arch="both" || {
+            echo -e "${YELLOW}Could not trigger Linux workflow.${NC}"
+        }
 fi
 
 echo ""
@@ -321,10 +338,13 @@ RELEASE_NOTES="## VapourBox $APP_VERSION
 - **Windows**: \`VapourBox-$APP_VERSION-windows-x64.zip\`
 - **macOS (Apple Silicon)**: \`VapourBox-$APP_VERSION-macos-arm64.zip\` (contains signed & notarized DMG)
 - **macOS (Intel)**: \`VapourBox-$APP_VERSION-macos-x64.zip\` (contains signed & notarized DMG)
+- **Linux (x64)**: \`VapourBox-$APP_VERSION-linux-x64.tar.gz\`
+- **Linux (arm64)**: \`VapourBox-$APP_VERSION-linux-arm64.tar.gz\`
 
 ### Installation
 - **Windows**: Extract zip and run \`vapourbox.exe\`
 - **macOS**: Open the DMG and drag VapourBox to Applications
+- **Linux**: Extract tarball and run \`./vapourbox\`
 
 ### Dependencies
 Dependencies are automatically downloaded on first launch (~185 MB).
@@ -332,7 +352,8 @@ Using dependency version: $DEPS_TAG
 
 ### Requirements
 - Windows 10/11 x64
-- macOS 12+ (Monterey or later)"
+- macOS 12+ (Monterey or later)
+- Linux x86_64 or aarch64 (Ubuntu 22.04+, Fedora 38+, or similar)"
 
 if [ ${#RELEASE_ASSETS[@]} -gt 0 ]; then
     gh release create "v$APP_VERSION" \
@@ -355,8 +376,8 @@ echo -e "${GREEN}║                    Release Complete!                       
 echo -e "${GREEN}╚════════════════════════════════════════════════════════════╝${NC}"
 echo ""
 echo "Next steps:"
-echo "  1. Wait for Windows build to complete (if using GitHub Actions)"
-echo "  2. Upload Windows zip to the draft release"
+echo "  1. Wait for Windows and Linux builds to complete (if using GitHub Actions)"
+echo "  2. Upload Windows zip and Linux tarballs to the draft release"
 echo "  3. Test the release builds"
 echo "  4. Edit release notes"
 echo "  5. Publish the release"

--- a/Scripts/run-debug-linux.sh
+++ b/Scripts/run-debug-linux.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Build and run VapourBox debug app on Linux.
+# Usage: ./Scripts/run-debug-linux.sh [--skip-worker] [--skip-app] [--run-only]
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+APP_DIR="$PROJECT_ROOT/app"
+WORKER_DIR="$PROJECT_ROOT/worker"
+
+# Detect architecture for bundle path
+ARCH=$(uname -m)
+if [ "$ARCH" = "aarch64" ]; then
+    FLUTTER_ARCH="arm64"
+else
+    FLUTTER_ARCH="x64"
+fi
+BUNDLE_DIR="$APP_DIR/build/linux/$FLUTTER_ARCH/debug/bundle"
+
+SKIP_WORKER=false
+SKIP_APP=false
+RUN_ONLY=false
+
+for arg in "$@"; do
+  case $arg in
+    --skip-worker) SKIP_WORKER=true ;;
+    --skip-app) SKIP_APP=true ;;
+    --run-only) RUN_ONLY=true ;;
+    -h|--help)
+      echo "Usage: $0 [--skip-worker] [--skip-app] [--run-only]"
+      echo ""
+      echo "Options:"
+      echo "  --skip-worker  Skip building the Rust worker"
+      echo "  --skip-app     Skip building the Flutter app"
+      echo "  --run-only     Skip all builds, just copy and launch"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $arg"
+      exit 1
+      ;;
+  esac
+done
+
+if $RUN_ONLY; then
+  SKIP_WORKER=true
+  SKIP_APP=true
+fi
+
+# Kill existing instance
+pkill -f "vapourbox" 2>/dev/null || true
+
+# Build Rust worker (debug)
+if ! $SKIP_WORKER; then
+  echo "==> Building worker (debug)..."
+  cd "$WORKER_DIR"
+  cargo build
+  echo "    Worker built."
+fi
+
+# Build Flutter app (debug)
+if ! $SKIP_APP; then
+  echo "==> Building Flutter app (debug)..."
+  cd "$APP_DIR"
+  flutter pub get --no-example > /dev/null 2>&1
+  flutter build linux --debug
+  echo "    Flutter app built."
+fi
+
+# Assemble debug bundle
+echo "==> Assembling debug bundle..."
+
+if [ ! -d "$BUNDLE_DIR" ]; then
+  echo "ERROR: Flutter bundle not found at $BUNDLE_DIR"
+  echo "Build the app first."
+  exit 1
+fi
+
+# Copy worker binary
+cp "$WORKER_DIR/target/debug/vapourbox-worker" "$BUNDLE_DIR/"
+
+# Copy templates
+mkdir -p "$BUNDLE_DIR/templates"
+cp "$WORKER_DIR/templates/"*.vpy "$BUNDLE_DIR/templates/"
+cp "$WORKER_DIR/templates/pipe_source.py" "$BUNDLE_DIR/templates/"
+cp "$WORKER_DIR/templates/spotless.py" "$BUNDLE_DIR/templates/"
+
+echo "==> Launching VapourBox (debug)..."
+"$BUNDLE_DIR/vapourbox" &
+echo "    Done. PID: $!"

--- a/app/assets/deps-version.json
+++ b/app/assets/deps-version.json
@@ -20,13 +20,13 @@
     },
     "linux-x64": {
       "filename": "VapourBox-deps-1.3.0-linux-x64.zip",
-      "sha256": "5d351e6ccae1e03d4d77d90ef333c13baaaf59a2aa740b529bf017e738c753d6",
-      "size": 143708426
+      "sha256": "431b9728b237f86b6160ef4e5a1b04bd789e3d59f91961132e2163fe7cc01797",
+      "size": 143784868
     },
     "linux-arm64": {
       "filename": "VapourBox-deps-1.3.0-linux-arm64.zip",
-      "sha256": "3d698f9f42154b94b3f2038e67ed20d54db718d09b80afe461b601b63eab98bd",
-      "size": 123871879
+      "sha256": "c21eb5e135c4fa6e1aa60befb577322b8cdf5ff63bc13681946e41f060b1cd36",
+      "size": 123911771
     }
   },
   "githubRepo": "StuartCameronCode/VapourBox"

--- a/app/assets/deps-version.json
+++ b/app/assets/deps-version.json
@@ -20,13 +20,13 @@
     },
     "linux-x64": {
       "filename": "VapourBox-deps-1.3.0-linux-x64.zip",
-      "sha256": null,
-      "size": null
+      "sha256": "5d351e6ccae1e03d4d77d90ef333c13baaaf59a2aa740b529bf017e738c753d6",
+      "size": 143708426
     },
     "linux-arm64": {
       "filename": "VapourBox-deps-1.3.0-linux-arm64.zip",
-      "sha256": "dd6d80570213729f2453cde6da7ae8b71f96bb6dc403ce3d85b5d392aa1115a4",
-      "size": 123969837
+      "sha256": "3d698f9f42154b94b3f2038e67ed20d54db718d09b80afe461b601b63eab98bd",
+      "size": 123871879
     }
   },
   "githubRepo": "StuartCameronCode/VapourBox"

--- a/app/assets/deps-version.json
+++ b/app/assets/deps-version.json
@@ -17,6 +17,16 @@
       "filename": "VapourBox-deps-1.3.0-macos-x64.zip",
       "sha256": "a326b662e34bb737269f6792b4b1b8518d8512bb05046cf430632a0213202abf",
       "size": 106078101
+    },
+    "linux-x64": {
+      "filename": "VapourBox-deps-1.3.0-linux-x64.zip",
+      "sha256": null,
+      "size": null
+    },
+    "linux-arm64": {
+      "filename": "VapourBox-deps-1.3.0-linux-arm64.zip",
+      "sha256": null,
+      "size": null
     }
   },
   "githubRepo": "StuartCameronCode/VapourBox"

--- a/app/assets/deps-version.json
+++ b/app/assets/deps-version.json
@@ -25,8 +25,8 @@
     },
     "linux-arm64": {
       "filename": "VapourBox-deps-1.3.0-linux-arm64.zip",
-      "sha256": null,
-      "size": null
+      "sha256": "dd6d80570213729f2453cde6da7ae8b71f96bb6dc403ce3d85b5d392aa1115a4",
+      "size": 123969837
     }
   },
   "githubRepo": "StuartCameronCode/VapourBox"

--- a/app/lib/services/dependency_manager.dart
+++ b/app/lib/services/dependency_manager.dart
@@ -161,6 +161,11 @@ class DependencyManager {
       final arch = result.stdout.toString().trim();
       return arch == 'arm64' ? 'macos-arm64' : 'macos-x64';
     }
+    if (Platform.isLinux) {
+      final result = Process.runSync('uname', ['-m']);
+      final arch = result.stdout.toString().trim();
+      return arch == 'aarch64' ? 'linux-arm64' : 'linux-x64';
+    }
     throw UnsupportedError('Unsupported platform');
   }
 
@@ -232,6 +237,29 @@ class DependencyManager {
       return Directory(path.join(
         home2, 'Library', 'Application Support', 'VapourBox', 'deps', platformId
       ));
+    } else if (Platform.isLinux) {
+      // Development only: check relative paths to project root
+      if (kDebugMode) {
+        // From app/build/linux/x64/debug/bundle/ up 6 levels
+        final devDeps = Directory(path.join(appDir, '..', '..', '..', '..', '..', '..', 'deps', platformId));
+        if (await devDeps.exists()) {
+          return Directory(await devDeps.resolveSymbolicLinks());
+        }
+      }
+
+      // Production: check XDG_DATA_HOME or ~/.local/share
+      final xdgDataHome = Platform.environment['XDG_DATA_HOME'];
+      final home = Platform.environment['HOME'] ?? '/tmp';
+      final dataDir = xdgDataHome != null
+          ? path.join(xdgDataHome, 'VapourBox', 'deps', platformId)
+          : path.join(home, '.local', 'share', 'VapourBox', 'deps', platformId);
+      final linuxDeps = Directory(dataDir);
+      if (await linuxDeps.exists()) {
+        return linuxDeps;
+      }
+
+      // Fall back to XDG path (will trigger download)
+      return linuxDeps;
     }
 
     throw UnsupportedError('Unsupported platform');
@@ -326,7 +354,7 @@ class DependencyManager {
         'vapoursynth/vs-plugins',
         'ffmpeg/ffmpeg.exe',
       ];
-    } else if (Platform.isMacOS) {
+    } else if (Platform.isMacOS || Platform.isLinux) {
       return [
         'vapoursynth/vspipe',
         'vapoursynth/plugins',

--- a/app/lib/services/disc_detector.dart
+++ b/app/lib/services/disc_detector.dart
@@ -22,6 +22,8 @@ class DiscDetector {
       return _detectMacOS();
     } else if (Platform.isWindows) {
       return _detectWindows();
+    } else if (Platform.isLinux) {
+      return _detectLinux();
     }
     return [];
   }
@@ -65,6 +67,42 @@ class DiscDetector {
         }
       } catch (_) {
         // Drive not accessible, skip
+      }
+    }
+
+    return discs;
+  }
+
+  Future<List<DvdDisc>> _detectLinux() async {
+    final discs = <DvdDisc>[];
+    final user = Platform.environment['USER'] ?? '';
+
+    // Scan common Linux mount points for VIDEO_TS directories
+    final mountDirs = <String>[
+      '/media/$user',       // Ubuntu auto-mount
+      '/run/media/$user',   // systemd auto-mount (Fedora/Arch)
+      '/mnt',               // Manual mounts
+    ];
+
+    for (final mountDir in mountDirs) {
+      final dir = Directory(mountDir);
+      if (!await dir.exists()) continue;
+
+      try {
+        await for (final entity in dir.list()) {
+          if (entity is Directory) {
+            final videoTsDir = Directory('${entity.path}/VIDEO_TS');
+            if (await videoTsDir.exists()) {
+              final label = entity.path.split('/').last;
+              discs.add(DvdDisc(
+                mountPoint: entity.path,
+                volumeLabel: label,
+              ));
+            }
+          }
+        }
+      } catch (_) {
+        // Directory not accessible, skip
       }
     }
 

--- a/app/lib/services/preview_generator.dart
+++ b/app/lib/services/preview_generator.dart
@@ -213,6 +213,7 @@ class PreviewGenerator {
     // We no longer double for FPSDivisor=1 because we're seeking in the source
     final frameNumber = (timeSeconds * _frameRate).round();
     final configPath = '$_tempDir/preview_config_${DateTime.now().millisecondsSinceEpoch}.json';
+    Process? process;
 
     try {
       // Set TFF based on field order for QTGMC
@@ -250,7 +251,7 @@ class PreviewGenerator {
       // Run worker in preview mode
       // Use local variable to avoid race conditions when another preview request cancels this one
       // Set workingDirectory to the worker's parent directory so relative deps paths resolve correctly
-      final process = await Process.start(
+      process = await Process.start(
         _workerPath!,
         [
           '--config', configPath,
@@ -299,7 +300,9 @@ class PreviewGenerator {
 
       // Wait for process to complete (use local variable to avoid race conditions)
       final exitCode = await process.exitCode;
-      _previewProcess = null;
+      if (_previewProcess == process) {
+        _previewProcess = null;
+      }
 
       // Log the result
       _previewLog.add('[${DateTime.now().toIso8601String()}] Process exited with code $exitCode, output size: ${pngBytes.length} bytes');
@@ -321,7 +324,9 @@ class PreviewGenerator {
       _lastError = 'Preview generation error: $e';
       _previewLog.add('[ERROR] $e');
     } finally {
-      _previewProcess = null;
+      if (_previewProcess == process) {
+        _previewProcess = null;
+      }
       // Clean up config file on error
       try {
         await File(configPath).delete();

--- a/app/lib/services/tool_locator.dart
+++ b/app/lib/services/tool_locator.dart
@@ -120,6 +120,12 @@ class ToolLocator {
           path.join(exeDir, '..', '..', '..', '..', '..', '..', '..', '..', '..', 'worker', 'target', 'release', workerExe),
           path.join(exeDir, '..', '..', '..', '..', '..', '..', '..', '..', '..', 'worker', 'target', 'debug', workerExe),
         ];
+      } else if (Platform.isLinux) {
+        // app/build/linux/x64/debug/bundle/ — 6 levels up
+        devPaths = [
+          path.join(exeDir, '..', '..', '..', '..', '..', '..', 'worker', 'target', 'release', workerExe),
+          path.join(exeDir, '..', '..', '..', '..', '..', '..', 'worker', 'target', 'debug', workerExe),
+        ];
       } else {
         devPaths = [];
       }
@@ -178,6 +184,34 @@ class ToolLocator {
       env['DYLD_LIBRARY_PATH'] = existingDyld.isEmpty
           ? dyldPaths.join(':')
           : '${dyldPaths.join(':')}:$existingDyld';
+    } else if (Platform.isLinux) {
+      final bundledPython = Directory(path.join(_depsDir!, 'python'));
+      if (await bundledPython.exists()) {
+        env['PYTHONHOME'] = path.join(_depsDir!, 'python');
+      }
+
+      env['PYTHONPATH'] = path.join(_depsDir!, 'python-packages');
+      env['PYTHONNOUSERSITE'] = '1';
+      env['VAPOURSYNTH_PLUGIN_PATH'] = path.join(_depsDir!, 'vapoursynth', 'plugins');
+
+      final paths = <String>[];
+      if (await bundledPython.exists()) {
+        paths.add(path.join(_depsDir!, 'python', 'bin'));
+      }
+      paths.add(path.join(_depsDir!, 'vapoursynth'));
+      paths.add(path.join(_depsDir!, 'ffmpeg'));
+      env['PATH'] = '${paths.join(':')}:${env['PATH'] ?? ''}';
+
+      // LD_LIBRARY_PATH for VapourSynth, Python, and extra libs
+      final ldPaths = [
+        path.join(_depsDir!, 'vapoursynth'),
+        path.join(_depsDir!, 'python', 'lib'),
+        path.join(_depsDir!, 'lib'),
+      ];
+      final existingLd = env['LD_LIBRARY_PATH'] ?? '';
+      env['LD_LIBRARY_PATH'] = existingLd.isEmpty
+          ? ldPaths.join(':')
+          : '${ldPaths.join(':')}:$existingLd';
     }
 
     return env;

--- a/app/lib/services/whisper_addon_manager.dart
+++ b/app/lib/services/whisper_addon_manager.dart
@@ -164,7 +164,9 @@ class WhisperAddonManager {
 
     final tempDir = await Directory.systemTemp.createTemp('vapourbox_whisper_');
     final tempFile = File(path.join(tempDir.path,
-        format == 'homebrew-bottle' ? 'whisper.tar.gz' : 'whisper.zip'));
+        (format == 'homebrew-bottle' || format == 'tar')
+            ? 'whisper.tar.gz'
+            : 'whisper.zip'));
 
     try {
       // ghcr.io requires a bearer token (public, anonymous access)
@@ -180,6 +182,8 @@ class WhisperAddonManager {
 
       if (format == 'homebrew-bottle') {
         await _extractHomebrewBottle(tempFile, whisperDir, exeName);
+      } else if (format == 'tar') {
+        await _extractTar(tempFile, whisperDir, exeName);
       } else {
         await _extractZip(tempFile, whisperDir, exeName);
       }
@@ -228,6 +232,33 @@ class WhisperAddonManager {
     ]);
     if (result.exitCode != 0) {
       throw StateError('Failed to extract bottle: ${result.stderr}');
+    }
+
+    // Set executable permissions on extracted binaries
+    final binDir = Directory(path.join(whisperDir.path, 'bin'));
+    if (await binDir.exists()) {
+      await for (final entity in binDir.list()) {
+        if (entity is File) {
+          await Process.run('chmod', ['+x', entity.path]);
+        }
+      }
+    }
+  }
+
+  /// Extract a plain gzipped tar (Linux binary release).
+  ///
+  /// The tarball is laid out as `bin/whisper-cli` (a fully static binary, no
+  /// `lib/` needed), matching the non-Windows whisperBinaryPath of
+  /// `whisper/bin/whisper-cli`. Unlike the Homebrew bottle, no path components
+  /// are stripped.
+  Future<void> _extractTar(
+      File tarGz, Directory whisperDir, String exeName) async {
+    final result = await Process.run('tar', [
+      'xzf', tarGz.path,
+      '-C', whisperDir.path,
+    ]);
+    if (result.exitCode != 0) {
+      throw StateError('Failed to extract tarball: ${result.stderr}');
     }
 
     // Set executable permissions on extracted binaries

--- a/app/lib/services/whisper_addon_manager.dart
+++ b/app/lib/services/whisper_addon_manager.dart
@@ -36,6 +36,11 @@ class WhisperAddonManager {
       final arch = result.stdout.toString().trim();
       return arch == 'arm64' ? 'macos-arm64' : 'macos-x64';
     }
+    if (Platform.isLinux) {
+      final result = Process.runSync('uname', ['-m']);
+      final arch = result.stdout.toString().trim();
+      return arch == 'aarch64' ? 'linux-arm64' : 'linux-x64';
+    }
     throw UnsupportedError('Unsupported platform');
   }
 
@@ -87,6 +92,26 @@ class WhisperAddonManager {
       return Directory(path.join(
         home, 'Library', 'Application Support', 'VapourBox', 'addons',
       ));
+    } else if (Platform.isLinux) {
+      if (kDebugMode) {
+        // Development: search upward for project addons
+        var current = Directory(appDir);
+        for (var i = 0; i < 10; i++) {
+          final addonsDir = Directory(path.join(current.path, 'addons'));
+          if (await addonsDir.exists()) {
+            return addonsDir;
+          }
+          final parent = current.parent;
+          if (parent.path == current.path) break;
+          current = parent;
+        }
+      }
+
+      // Production: XDG_DATA_HOME or ~/.local/share
+      final xdgDataHome = Platform.environment['XDG_DATA_HOME'];
+      final home = Platform.environment['HOME'] ?? '/tmp';
+      final dataDir = xdgDataHome ?? path.join(home, '.local', 'share');
+      return Directory(path.join(dataDir, 'VapourBox', 'addons'));
     }
 
     throw UnsupportedError('Unsupported platform');

--- a/app/lib/viewmodels/main_viewmodel.dart
+++ b/app/lib/viewmodels/main_viewmodel.dart
@@ -61,6 +61,7 @@ class MainViewModel extends ChangeNotifier {
   bool _isGeneratingPreview = false;
   CancelToken? _previewCancelToken;
   Timer? _previewDebounceTimer;
+  int _previewGeneration = 0;
   Timer? _zoomDebounceTimer;
   bool _isLoadingZoomedThumbnails = false;
 
@@ -785,6 +786,11 @@ class MainViewModel extends ChangeNotifier {
   }
 
   /// Generates the processed preview at the current scrubber position.
+  ///
+  /// Uses a generation counter to handle concurrent calls safely. The timer
+  /// callback cannot await this async method, so multiple calls can overlap
+  /// when filters are toggled rapidly. Only the most recent generation is
+  /// allowed to update shared state (_isGeneratingPreview, processedPreview).
   Future<void> _generateProcessedPreview() async {
     final item = selectedItem;
     if (item == null) return;
@@ -792,10 +798,13 @@ class MainViewModel extends ChangeNotifier {
     // Cancel any existing preview generation
     _cancelPreviewGeneration();
 
+    final generation = ++_previewGeneration;
+
     _isGeneratingPreview = true;
     notifyListeners();
 
-    _previewCancelToken = CancelToken();
+    final cancelToken = CancelToken();
+    _previewCancelToken = cancelToken;
     final timeSeconds = item.scrubberPosition * _previewGenerator.duration;
 
     try {
@@ -804,18 +813,22 @@ class MainViewModel extends ChangeNotifier {
         pipeline: _processingPipeline,
         fieldOrder: effectiveFieldOrder,
         encodingSettings: _encodingSettings,
-        cancelToken: _previewCancelToken,
+        cancelToken: cancelToken,
       );
 
-      if (!(_previewCancelToken?.isCancelled ?? true)) {
+      if (generation == _previewGeneration && !cancelToken.isCancelled) {
         item.processedPreview = preview;
       }
     } catch (e) {
       // Ignore errors from cancelled previews
     }
 
-    _isGeneratingPreview = false;
-    notifyListeners();
+    // Only clear the generating flag if this is still the latest generation.
+    // Otherwise a newer call is in flight and owns the flag.
+    if (generation == _previewGeneration) {
+      _isGeneratingPreview = false;
+      notifyListeners();
+    }
   }
 
   /// Cancels any ongoing preview generation.

--- a/app/lib/views/queue_panel.dart
+++ b/app/lib/views/queue_panel.dart
@@ -290,6 +290,9 @@ class _QueuePanelState extends State<QueuePanel> {
       Process.run('open', ['-R', path]);
     } else if (Platform.isWindows) {
       Process.run('explorer', ['/select,', path]);
+    } else if (Platform.isLinux) {
+      final parent = File(path).parent.path;
+      Process.run('xdg-open', [parent]);
     }
   }
 

--- a/app/lib/views/settings/settings_dialog.dart
+++ b/app/lib/views/settings/settings_dialog.dart
@@ -911,6 +911,9 @@ class _OutputSettingsTabState extends State<_OutputSettingsTab> {
       Process.run('open', ['-R', path]);
     } else if (Platform.isWindows) {
       Process.run('explorer', ['/select,', path]);
+    } else if (Platform.isLinux) {
+      final parent = File(path).parent.path;
+      Process.run('xdg-open', [parent]);
     }
   }
 

--- a/app/linux/.gitignore
+++ b/app/linux/.gitignore
@@ -1,0 +1,1 @@
+flutter/ephemeral

--- a/app/linux/CMakeLists.txt
+++ b/app/linux/CMakeLists.txt
@@ -1,0 +1,128 @@
+# Project-level configuration.
+cmake_minimum_required(VERSION 3.13)
+project(runner LANGUAGES CXX)
+
+# The name of the executable created for the application. Change this to change
+# the on-disk name of your application.
+set(BINARY_NAME "vapourbox")
+# The unique GTK application identifier for this application. See:
+# https://wiki.gnome.org/HowDoI/ChooseApplicationID
+set(APPLICATION_ID "app.vapourbox.VapourBox")
+
+# Explicitly opt in to modern CMake behaviors to avoid warnings with recent
+# versions of CMake.
+cmake_policy(SET CMP0063 NEW)
+
+# Load bundled libraries from the lib/ directory relative to the binary.
+set(CMAKE_INSTALL_RPATH "$ORIGIN/lib")
+
+# Root filesystem for cross-building.
+if(FLUTTER_TARGET_PLATFORM_SYSROOT)
+  set(CMAKE_SYSROOT ${FLUTTER_TARGET_PLATFORM_SYSROOT})
+  set(CMAKE_FIND_ROOT_PATH ${CMAKE_SYSROOT})
+  set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+  set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+endif()
+
+# Define build configuration options.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE "Debug" CACHE
+    STRING "Flutter build mode" FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Profile" "Release")
+endif()
+
+# Compilation settings that should be applied to most targets.
+#
+# Be cautious about adding new options here, as plugins use this function by
+# default. In most cases, you should add new options to specific targets instead
+# of modifying this function.
+function(APPLY_STANDARD_SETTINGS TARGET)
+  target_compile_features(${TARGET} PUBLIC cxx_std_14)
+  target_compile_options(${TARGET} PRIVATE -Wall -Werror)
+  target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
+  target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
+endfunction()
+
+# Flutter library and tool build rules.
+set(FLUTTER_MANAGED_DIR "${CMAKE_CURRENT_SOURCE_DIR}/flutter")
+add_subdirectory(${FLUTTER_MANAGED_DIR})
+
+# System-level dependencies.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+
+# Application build; see runner/CMakeLists.txt.
+add_subdirectory("runner")
+
+# Run the Flutter tool portions of the build. This must not be removed.
+add_dependencies(${BINARY_NAME} flutter_assemble)
+
+# Only the install-generated bundle's copy of the executable will launch
+# correctly, since the resources must in the right relative locations. To avoid
+# people trying to run the unbundled copy, put it in a subdirectory instead of
+# the default top-level location.
+set_target_properties(${BINARY_NAME}
+  PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/intermediates_do_not_run"
+)
+
+
+# Generated plugin build rules, which manage building the plugins and adding
+# them to the application.
+include(flutter/generated_plugins.cmake)
+
+
+# === Installation ===
+# By default, "installing" just makes a relocatable bundle in the build
+# directory.
+set(BUILD_BUNDLE_DIR "${PROJECT_BINARY_DIR}/bundle")
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX "${BUILD_BUNDLE_DIR}" CACHE PATH "..." FORCE)
+endif()
+
+# Start with a clean build bundle directory every time.
+install(CODE "
+  file(REMOVE_RECURSE \"${BUILD_BUNDLE_DIR}/\")
+  " COMPONENT Runtime)
+
+set(INSTALL_BUNDLE_DATA_DIR "${CMAKE_INSTALL_PREFIX}/data")
+set(INSTALL_BUNDLE_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+
+install(TARGETS ${BINARY_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_ICU_DATA_FILE}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+  COMPONENT Runtime)
+
+foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
+  install(FILES "${bundled_library}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endforeach(bundled_library)
+
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
+# Fully re-copy the assets directory on each build to avoid having stale files
+# from a previous install.
+set(FLUTTER_ASSET_DIR_NAME "flutter_assets")
+install(CODE "
+  file(REMOVE_RECURSE \"${INSTALL_BUNDLE_DATA_DIR}/${FLUTTER_ASSET_DIR_NAME}\")
+  " COMPONENT Runtime)
+install(DIRECTORY "${PROJECT_BUILD_DIR}/${FLUTTER_ASSET_DIR_NAME}"
+  DESTINATION "${INSTALL_BUNDLE_DATA_DIR}" COMPONENT Runtime)
+
+# Install the AOT library on non-Debug builds only.
+if(NOT CMAKE_BUILD_TYPE MATCHES "Debug")
+  install(FILES "${AOT_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()

--- a/app/linux/flutter/CMakeLists.txt
+++ b/app/linux/flutter/CMakeLists.txt
@@ -1,0 +1,88 @@
+# This file controls Flutter-level build steps. It should not be edited.
+cmake_minimum_required(VERSION 3.10)
+
+set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
+
+# Configuration provided via flutter tool.
+include(${EPHEMERAL_DIR}/generated_config.cmake)
+
+# TODO: Move the rest of this into files in ephemeral. See
+# https://github.com/flutter/flutter/issues/57146.
+
+# Serves the same purpose as list(TRANSFORM ... PREPEND ...),
+# which isn't available in 3.10.
+function(list_prepend LIST_NAME PREFIX)
+    set(NEW_LIST "")
+    foreach(element ${${LIST_NAME}})
+        list(APPEND NEW_LIST "${PREFIX}${element}")
+    endforeach(element)
+    set(${LIST_NAME} "${NEW_LIST}" PARENT_SCOPE)
+endfunction()
+
+# === Flutter Library ===
+# System-level dependencies.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0)
+pkg_check_modules(GIO REQUIRED IMPORTED_TARGET gio-2.0)
+
+set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/libflutter_linux_gtk.so")
+
+# Published to parent scope for install step.
+set(FLUTTER_LIBRARY ${FLUTTER_LIBRARY} PARENT_SCOPE)
+set(FLUTTER_ICU_DATA_FILE "${EPHEMERAL_DIR}/icudtl.dat" PARENT_SCOPE)
+set(PROJECT_BUILD_DIR "${PROJECT_DIR}/build/" PARENT_SCOPE)
+set(AOT_LIBRARY "${PROJECT_DIR}/build/lib/libapp.so" PARENT_SCOPE)
+
+list(APPEND FLUTTER_LIBRARY_HEADERS
+  "fl_basic_message_channel.h"
+  "fl_binary_codec.h"
+  "fl_binary_messenger.h"
+  "fl_dart_project.h"
+  "fl_engine.h"
+  "fl_json_message_codec.h"
+  "fl_json_method_codec.h"
+  "fl_message_codec.h"
+  "fl_method_call.h"
+  "fl_method_channel.h"
+  "fl_method_codec.h"
+  "fl_method_response.h"
+  "fl_plugin_registrar.h"
+  "fl_plugin_registry.h"
+  "fl_standard_message_codec.h"
+  "fl_standard_method_codec.h"
+  "fl_string_codec.h"
+  "fl_value.h"
+  "fl_view.h"
+  "flutter_linux.h"
+)
+list_prepend(FLUTTER_LIBRARY_HEADERS "${EPHEMERAL_DIR}/flutter_linux/")
+add_library(flutter INTERFACE)
+target_include_directories(flutter INTERFACE
+  "${EPHEMERAL_DIR}"
+)
+target_link_libraries(flutter INTERFACE "${FLUTTER_LIBRARY}")
+target_link_libraries(flutter INTERFACE
+  PkgConfig::GTK
+  PkgConfig::GLIB
+  PkgConfig::GIO
+)
+add_dependencies(flutter flutter_assemble)
+
+# === Flutter tool backend ===
+# _phony_ is a non-existent file to force this command to run every time,
+# since currently there's no way to get a full input/output list from the
+# flutter tool.
+add_custom_command(
+  OUTPUT ${FLUTTER_LIBRARY} ${FLUTTER_LIBRARY_HEADERS}
+    ${CMAKE_CURRENT_BINARY_DIR}/_phony_
+  COMMAND ${CMAKE_COMMAND} -E env
+    ${FLUTTER_TOOL_ENVIRONMENT}
+    "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
+      ${FLUTTER_TARGET_PLATFORM} ${CMAKE_BUILD_TYPE}
+  VERBATIM
+)
+add_custom_target(flutter_assemble DEPENDS
+  "${FLUTTER_LIBRARY}"
+  ${FLUTTER_LIBRARY_HEADERS}
+)

--- a/app/linux/flutter/generated_plugin_registrant.cc
+++ b/app/linux/flutter/generated_plugin_registrant.cc
@@ -1,0 +1,27 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#include "generated_plugin_registrant.h"
+
+#include <desktop_drop/desktop_drop_plugin.h>
+#include <screen_retriever_linux/screen_retriever_linux_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
+#include <window_manager/window_manager_plugin.h>
+
+void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) desktop_drop_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "DesktopDropPlugin");
+  desktop_drop_plugin_register_with_registrar(desktop_drop_registrar);
+  g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
+  screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
+  g_autoptr(FlPluginRegistrar) window_manager_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "WindowManagerPlugin");
+  window_manager_plugin_register_with_registrar(window_manager_registrar);
+}

--- a/app/linux/flutter/generated_plugin_registrant.h
+++ b/app/linux/flutter/generated_plugin_registrant.h
@@ -1,0 +1,15 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#ifndef GENERATED_PLUGIN_REGISTRANT_
+#define GENERATED_PLUGIN_REGISTRANT_
+
+#include <flutter_linux/flutter_linux.h>
+
+// Registers Flutter plugins.
+void fl_register_plugins(FlPluginRegistry* registry);
+
+#endif  // GENERATED_PLUGIN_REGISTRANT_

--- a/app/linux/flutter/generated_plugins.cmake
+++ b/app/linux/flutter/generated_plugins.cmake
@@ -1,0 +1,29 @@
+#
+# Generated file, do not edit.
+#
+
+list(APPEND FLUTTER_PLUGIN_LIST
+  desktop_drop
+  screen_retriever_linux
+  url_launcher_linux
+  window_manager
+)
+
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
+  rhttp
+)
+
+set(PLUGIN_BUNDLED_LIBRARIES)
+
+foreach(plugin ${FLUTTER_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${plugin}/linux plugins/${plugin})
+  target_link_libraries(${BINARY_NAME} PRIVATE ${plugin}_plugin)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
+endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/linux plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/app/linux/runner/CMakeLists.txt
+++ b/app/linux/runner/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.13)
+project(runner LANGUAGES CXX)
+
+# Define the application target. To change its name, change BINARY_NAME in the
+# top-level CMakeLists.txt, not the value here, or `flutter run` will no longer
+# work.
+#
+# Any new source files that you add to the application should be added here.
+add_executable(${BINARY_NAME}
+  "main.cc"
+  "my_application.cc"
+  "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
+)
+
+# Apply the standard set of build settings. This can be removed for applications
+# that need different build settings.
+apply_standard_settings(${BINARY_NAME})
+
+# Add preprocessor definitions for the application ID.
+add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
+
+# Add dependency libraries. Add any application-specific dependencies here.
+target_link_libraries(${BINARY_NAME} PRIVATE flutter)
+target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
+
+target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")

--- a/app/linux/runner/main.cc
+++ b/app/linux/runner/main.cc
@@ -1,0 +1,6 @@
+#include "my_application.h"
+
+int main(int argc, char** argv) {
+  g_autoptr(MyApplication) app = my_application_new();
+  return g_application_run(G_APPLICATION(app), argc, argv);
+}

--- a/app/linux/runner/my_application.cc
+++ b/app/linux/runner/my_application.cc
@@ -1,0 +1,148 @@
+#include "my_application.h"
+
+#include <flutter_linux/flutter_linux.h>
+#ifdef GDK_WINDOWING_X11
+#include <gdk/gdkx.h>
+#endif
+
+#include "flutter/generated_plugin_registrant.h"
+
+struct _MyApplication {
+  GtkApplication parent_instance;
+  char** dart_entrypoint_arguments;
+};
+
+G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
+
+// Called when first Flutter frame received.
+static void first_frame_cb(MyApplication* self, FlView* view) {
+  gtk_widget_show(gtk_widget_get_toplevel(GTK_WIDGET(view)));
+}
+
+// Implements GApplication::activate.
+static void my_application_activate(GApplication* application) {
+  MyApplication* self = MY_APPLICATION(application);
+  GtkWindow* window =
+      GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
+
+  // Use a header bar when running in GNOME as this is the common style used
+  // by applications and is the setup most users will be using (e.g. Ubuntu
+  // desktop).
+  // If running on X and not using GNOME then just use a traditional title bar
+  // in case the window manager does more exotic layout, e.g. tiling.
+  // If running on Wayland assume the header bar will work (may need changing
+  // if future cases occur).
+  gboolean use_header_bar = TRUE;
+#ifdef GDK_WINDOWING_X11
+  GdkScreen* screen = gtk_window_get_screen(window);
+  if (GDK_IS_X11_SCREEN(screen)) {
+    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
+    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
+      use_header_bar = FALSE;
+    }
+  }
+#endif
+  if (use_header_bar) {
+    GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
+    gtk_widget_show(GTK_WIDGET(header_bar));
+    gtk_header_bar_set_title(header_bar, "vapourbox");
+    gtk_header_bar_set_show_close_button(header_bar, TRUE);
+    gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
+  } else {
+    gtk_window_set_title(window, "vapourbox");
+  }
+
+  gtk_window_set_default_size(window, 1280, 720);
+
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+  fl_dart_project_set_dart_entrypoint_arguments(
+      project, self->dart_entrypoint_arguments);
+
+  FlView* view = fl_view_new(project);
+  GdkRGBA background_color;
+  // Background defaults to black, override it here if necessary, e.g. #00000000
+  // for transparent.
+  gdk_rgba_parse(&background_color, "#000000");
+  fl_view_set_background_color(view, &background_color);
+  gtk_widget_show(GTK_WIDGET(view));
+  gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
+
+  // Show the window when Flutter renders.
+  // Requires the view to be realized so we can start rendering.
+  g_signal_connect_swapped(view, "first-frame", G_CALLBACK(first_frame_cb),
+                           self);
+  gtk_widget_realize(GTK_WIDGET(view));
+
+  fl_register_plugins(FL_PLUGIN_REGISTRY(view));
+
+  gtk_widget_grab_focus(GTK_WIDGET(view));
+}
+
+// Implements GApplication::local_command_line.
+static gboolean my_application_local_command_line(GApplication* application,
+                                                  gchar*** arguments,
+                                                  int* exit_status) {
+  MyApplication* self = MY_APPLICATION(application);
+  // Strip out the first argument as it is the binary name.
+  self->dart_entrypoint_arguments = g_strdupv(*arguments + 1);
+
+  g_autoptr(GError) error = nullptr;
+  if (!g_application_register(application, nullptr, &error)) {
+    g_warning("Failed to register: %s", error->message);
+    *exit_status = 1;
+    return TRUE;
+  }
+
+  g_application_activate(application);
+  *exit_status = 0;
+
+  return TRUE;
+}
+
+// Implements GApplication::startup.
+static void my_application_startup(GApplication* application) {
+  // MyApplication* self = MY_APPLICATION(object);
+
+  // Perform any actions required at application startup.
+
+  G_APPLICATION_CLASS(my_application_parent_class)->startup(application);
+}
+
+// Implements GApplication::shutdown.
+static void my_application_shutdown(GApplication* application) {
+  // MyApplication* self = MY_APPLICATION(object);
+
+  // Perform any actions required at application shutdown.
+
+  G_APPLICATION_CLASS(my_application_parent_class)->shutdown(application);
+}
+
+// Implements GObject::dispose.
+static void my_application_dispose(GObject* object) {
+  MyApplication* self = MY_APPLICATION(object);
+  g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
+  G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
+}
+
+static void my_application_class_init(MyApplicationClass* klass) {
+  G_APPLICATION_CLASS(klass)->activate = my_application_activate;
+  G_APPLICATION_CLASS(klass)->local_command_line =
+      my_application_local_command_line;
+  G_APPLICATION_CLASS(klass)->startup = my_application_startup;
+  G_APPLICATION_CLASS(klass)->shutdown = my_application_shutdown;
+  G_OBJECT_CLASS(klass)->dispose = my_application_dispose;
+}
+
+static void my_application_init(MyApplication* self) {}
+
+MyApplication* my_application_new() {
+  // Set the program name to the application ID, which helps various systems
+  // like GTK and desktop environments map this running application to its
+  // corresponding .desktop file. This ensures better integration by allowing
+  // the application to be recognized beyond its binary name.
+  g_set_prgname(APPLICATION_ID);
+
+  return MY_APPLICATION(g_object_new(my_application_get_type(),
+                                     "application-id", APPLICATION_ID, "flags",
+                                     G_APPLICATION_NON_UNIQUE, nullptr));
+}

--- a/app/linux/runner/my_application.h
+++ b/app/linux/runner/my_application.h
@@ -1,0 +1,21 @@
+#ifndef FLUTTER_MY_APPLICATION_H_
+#define FLUTTER_MY_APPLICATION_H_
+
+#include <gtk/gtk.h>
+
+G_DECLARE_FINAL_TYPE(MyApplication,
+                     my_application,
+                     MY,
+                     APPLICATION,
+                     GtkApplication)
+
+/**
+ * my_application_new:
+ *
+ * Creates a new Flutter-based application.
+ *
+ * Returns: a new #MyApplication.
+ */
+MyApplication* my_application_new();
+
+#endif  // FLUTTER_MY_APPLICATION_H_

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: vapourbox
 description: "Video processing and cleanup powered by VapourSynth"
 publish_to: 'none'
-version: 0.9.6+21
+version: 1.0.0-alpha+20
 
 environment:
   sdk: ^3.6.2

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -1,7 +1,7 @@
 name: vapourbox
 description: "Video processing and cleanup powered by VapourSynth"
 publish_to: 'none'
-version: 1.0.0-alpha+20
+version: 0.9.6+21
 
 environment:
   sdk: ^3.6.2

--- a/app/test/vapoursynth_integration_test.dart
+++ b/app/test/vapoursynth_integration_test.dart
@@ -35,6 +35,12 @@ void main() {
       depsPlatform = arch == 'arm64' ? 'macos-arm64' : 'macos-x64';
       vspipeExe = 'vspipe';
       ffmpegExe = 'ffmpeg';
+    } else if (Platform.isLinux) {
+      final archResult = await Process.run('uname', ['-m']);
+      final arch = archResult.stdout.toString().trim();
+      depsPlatform = arch == 'aarch64' ? 'linux-arm64' : 'linux-x64';
+      vspipeExe = 'vspipe';
+      ffmpegExe = 'ffmpeg';
     } else {
       throw UnsupportedError(
           'Unsupported platform: ${Platform.operatingSystem}');
@@ -377,7 +383,7 @@ Future<ProcessResult> _runVspipeScript(
         'VAPOURSYNTH_PLUGIN_PATH': path.join(vsDir, 'vs-plugins'),
       };
     } else {
-      // macOS - the vspipe wrapper script handles most env setup
+      // macOS/Linux - the vspipe wrapper script handles most env setup
       environment = {
         'PYTHONPATH': path.join(depsDir, 'python-packages'),
       };

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vapourbox-worker"
-version = "1.0.0-alpha"
+version = "0.9.6"
 edition = "2021"
 description = "Video processing worker using VapourSynth"
 authors = ["Stuart Cameron"]

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vapourbox-worker"
-version = "0.9.6"
+version = "1.0.0-alpha"
 edition = "2021"
 description = "Video processing worker using VapourSynth"
 authors = ["Stuart Cameron"]

--- a/worker/src/dependency_locator.rs
+++ b/worker/src/dependency_locator.rs
@@ -33,11 +33,13 @@ impl DependencyLocator {
     }
 
     /// Find the deps directory by searching various locations.
-    fn find_deps_directory(exe_path: &Path) -> Result<PathBuf> {
-        // Development only: search upward from executable for project deps.
+    fn find_deps_directory(#[allow(unused)] exe_path: &Path) -> Result<PathBuf> {
+        // Development only (macOS/Windows): search upward from executable for project deps.
         // This is restricted to debug builds for security - release builds
         // should only check known production paths.
-        #[cfg(debug_assertions)]
+        // Linux always uses the production path since deps are built/downloaded
+        // separately and installed to ~/.local/share/VapourBox/deps/.
+        #[cfg(all(debug_assertions, not(target_os = "linux")))]
         {
             let mut current = exe_path.parent();
             while let Some(dir) = current {
@@ -47,9 +49,7 @@ impl DependencyLocator {
                     // to distinguish from Cargo's deps folder.
                     let has_platform_dir = deps_dir.join("windows-x64").exists()
                         || deps_dir.join("macos-arm64").exists()
-                        || deps_dir.join("macos-x64").exists()
-                        || deps_dir.join("linux-x64").exists()
-                        || deps_dir.join("linux-arm64").exists();
+                        || deps_dir.join("macos-x64").exists();
                     if has_platform_dir {
                         return Ok(deps_dir);
                     }

--- a/worker/src/dependency_locator.rs
+++ b/worker/src/dependency_locator.rs
@@ -18,6 +18,8 @@ pub enum Platform {
     MacOSX64,
     WindowsX64,
     WindowsArm64,
+    LinuxX64,
+    LinuxArm64,
 }
 
 impl DependencyLocator {
@@ -45,7 +47,9 @@ impl DependencyLocator {
                     // to distinguish from Cargo's deps folder.
                     let has_platform_dir = deps_dir.join("windows-x64").exists()
                         || deps_dir.join("macos-arm64").exists()
-                        || deps_dir.join("macos-x64").exists();
+                        || deps_dir.join("macos-x64").exists()
+                        || deps_dir.join("linux-x64").exists()
+                        || deps_dir.join("linux-arm64").exists();
                     if has_platform_dir {
                         return Ok(deps_dir);
                     }
@@ -82,6 +86,29 @@ impl DependencyLocator {
             }
         }
 
+        // Linux production: XDG_DATA_HOME or ~/.local/share (where downloaded deps go)
+        #[cfg(target_os = "linux")]
+        {
+            let data_dir = if let Ok(xdg) = env::var("XDG_DATA_HOME") {
+                PathBuf::from(xdg).join("VapourBox").join("deps")
+            } else if let Some(home) = env::var_os("HOME") {
+                PathBuf::from(home)
+                    .join(".local")
+                    .join("share")
+                    .join("VapourBox")
+                    .join("deps")
+            } else {
+                PathBuf::from("deps")
+            };
+            if data_dir.join("linux-x64").exists()
+                || data_dir.join("linux-arm64").exists() {
+                return Ok(data_dir);
+            }
+            // Fallback to XDG path (will be created when deps download)
+            return Ok(data_dir);
+        }
+
+        #[allow(unreachable_code)]
         Ok(PathBuf::from("deps"))
     }
 
@@ -99,7 +126,13 @@ impl DependencyLocator {
         #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
         return Platform::WindowsArm64;
 
-        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+        #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+        return Platform::LinuxX64;
+
+        #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+        return Platform::LinuxArm64;
+
+        #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
         compile_error!("Unsupported platform");
     }
 
@@ -110,6 +143,8 @@ impl DependencyLocator {
             Platform::MacOSX64 => "macos-x64",
             Platform::WindowsX64 => "windows-x64",
             Platform::WindowsArm64 => "windows-arm64",
+            Platform::LinuxX64 => "linux-x64",
+            Platform::LinuxArm64 => "linux-arm64",
         }
     }
 
@@ -222,6 +257,16 @@ impl DependencyLocator {
             // Windows: Python 3.8 is bundled inside VapourSynth portable
             Some(platform_dir.join("vapoursynth"))
         }
+
+        #[cfg(target_os = "linux")]
+        {
+            // Linux: python-build-standalone, same layout as macOS
+            let python_dir = platform_dir.join("python");
+            if python_dir.join("bin").join("python3.12").exists() {
+                return Some(python_dir);
+            }
+            None
+        }
     }
 
     /// Get the Python path (site-packages and custom packages).
@@ -241,6 +286,16 @@ impl DependencyLocator {
                 // Legacy support for other Python versions
                 paths.push(python_home.join("lib").join("python3.14").join("site-packages").to_string_lossy().to_string());
                 paths.push(python_home.join("lib").join("python3.11").join("site-packages").to_string_lossy().to_string());
+            }
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            // Linux: same layout as macOS
+            paths.push(platform_dir.join("python-packages").to_string_lossy().to_string());
+
+            if let Some(python_home) = self.python_home() {
+                paths.push(python_home.join("lib").join("python3.12").join("site-packages").to_string_lossy().to_string());
             }
         }
 
@@ -301,6 +356,14 @@ impl DependencyLocator {
             }
         }
 
+        #[cfg(target_os = "linux")]
+        {
+            // Add bundled Python bin if available (same as macOS)
+            if let Some(python_home) = self.python_home() {
+                paths.push(python_home.join("bin").to_string_lossy().to_string());
+            }
+        }
+
         // On Windows, Python is bundled inside vapoursynth directory (already in path)
 
         #[cfg(target_os = "windows")]
@@ -349,6 +412,20 @@ impl DependencyLocator {
             }
         }
 
+        #[cfg(target_os = "linux")]
+        {
+            if let Ok(xdg) = env::var("XDG_DATA_HOME") {
+                return PathBuf::from(xdg).join("VapourBox").join("addons");
+            }
+            if let Some(home) = env::var_os("HOME") {
+                return PathBuf::from(home)
+                    .join(".local")
+                    .join("share")
+                    .join("VapourBox")
+                    .join("addons");
+            }
+        }
+
         PathBuf::from("addons")
     }
 
@@ -364,6 +441,11 @@ impl DependencyLocator {
         #[cfg(target_os = "windows")]
         {
             platform_dir.join("lib").join("dvdread.dll")
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            platform_dir.join("lib").join("libdvdread.so")
         }
     }
 
@@ -450,6 +532,42 @@ impl DependencyLocator {
             // and ignores system plugins (which could conflict).
             // This replaces the config generation in the vspipe wrapper script,
             // allowing us to call vspipe-bin directly (so kill() works).
+            let plugins_dir = vs_lib_path.join("plugins");
+            let conf_path = vs_lib_path.join("vapoursynth.auto.conf");
+            let conf_content = format!(
+                "UserPluginDir={}\nAutoloadUserPluginDir=true\nAutoloadSystemPluginDir=false\n",
+                plugins_dir.to_string_lossy()
+            );
+            let _ = std::fs::write(&conf_path, &conf_content);
+            env.insert("VAPOURSYNTH_CONF_PATH".to_string(), conf_path.to_string_lossy().to_string());
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            // Linux library path for VapourSynth and Python
+            let vs_lib_path = self.platform_dir().join("vapoursynth");
+            let python_lib_path = self.platform_dir().join("python").join("lib");
+            let extra_lib_path = self.platform_dir().join("lib");
+            let existing_ld = std::env::var("LD_LIBRARY_PATH").unwrap_or_default();
+            let new_ld = if existing_ld.is_empty() {
+                format!(
+                    "{}:{}:{}",
+                    vs_lib_path.to_string_lossy(),
+                    python_lib_path.to_string_lossy(),
+                    extra_lib_path.to_string_lossy()
+                )
+            } else {
+                format!(
+                    "{}:{}:{}:{}",
+                    vs_lib_path.to_string_lossy(),
+                    python_lib_path.to_string_lossy(),
+                    extra_lib_path.to_string_lossy(),
+                    existing_ld
+                )
+            };
+            env.insert("LD_LIBRARY_PATH".to_string(), new_ld);
+
+            // Generate VapourSynth config (same as macOS)
             let plugins_dir = vs_lib_path.join("plugins");
             let conf_path = vs_lib_path.join("vapoursynth.auto.conf");
             let conf_content = format!(

--- a/worker/src/dvd_reader.rs
+++ b/worker/src/dvd_reader.rs
@@ -674,9 +674,32 @@ impl DvdReadLib {
             }
         }
 
+        #[cfg(target_os = "linux")]
+        {
+            let paths = [
+                "/usr/lib/x86_64-linux-gnu/libdvdread.so",  // Debian/Ubuntu
+                "/usr/lib64/libdvdread.so",                  // Fedora/RHEL
+                "/usr/lib/libdvdread.so",                    // Arch
+                "/usr/local/lib/libdvdread.so",
+            ];
+            for path in &paths {
+                let p = Path::new(path);
+                if p.exists() {
+                    if let Ok(lib) = Self::load(p) {
+                        return Ok(lib);
+                    }
+                }
+            }
+            // Try generic name (searches LD_LIBRARY_PATH)
+            if let Ok(lib) = Self::load(Path::new("libdvdread.so")) {
+                return Ok(lib);
+            }
+        }
+
         bail!(
             "libdvdread not found. DVD extraction requires libdvdread.\n\
              macOS: brew install libdvdread\n\
+             Linux: sudo apt install libdvdread-dev (Debian/Ubuntu) or sudo dnf install libdvdread-devel (Fedora)\n\
              Windows: place dvdread.dll in the application directory"
         )
     }

--- a/worker/src/pipeline_executor.rs
+++ b/worker/src/pipeline_executor.rs
@@ -9,7 +9,34 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
+#[cfg(unix)]
+use std::os::unix::process::ExitStatusExt;
+
 use anyhow::{bail, Context, Result};
+
+/// Format an exit status for error messages, including signal info on Unix.
+fn format_exit_status(status: &std::process::ExitStatus) -> String {
+    if let Some(code) = status.code() {
+        return format!("exit code {}", code);
+    }
+    #[cfg(unix)]
+    {
+        if let Some(sig) = status.signal() {
+            let name = match sig {
+                1 => "SIGHUP",
+                2 => "SIGINT",
+                6 => "SIGABRT",
+                9 => "SIGKILL",
+                11 => "SIGSEGV",
+                13 => "SIGPIPE",
+                15 => "SIGTERM",
+                _ => "unknown",
+            };
+            return format!("signal {} ({})", sig, name);
+        }
+    }
+    "unknown status".to_string()
+}
 
 use crate::dependency_locator::DependencyLocator;
 use crate::models::{AudioMode, ContainerFormat, DeinterlaceMethod, EncoderFamily, EncodingSettings, LogLevel, ProgressInfo, SubtitleOutput, VideoCodec, VideoJob};
@@ -370,21 +397,21 @@ impl PipelineExecutor {
         if let Some(status) = decoder_status {
             let code = status.code().unwrap_or(-1);
             if code != 0 && code != 130 && code != 141 && code != 224 {
-                bail!("Decoder ffmpeg exited with code {}", code);
+                bail!("Decoder ffmpeg exited with {}", format_exit_status(&status));
             }
         }
 
         if let Some(status) = vspipe_status {
             let code = status.code().unwrap_or(-1);
             if code != 0 && code != 130 && code != 141 {
-                bail!("vspipe exited with code {}", code);
+                bail!("vspipe exited with {}", format_exit_status(&status));
             }
         }
 
         let ffmpeg_ok = if let Some(status) = ffmpeg_status {
             let code = status.code().unwrap_or(-1);
             if code != 0 && code != 130 && code != 141 {
-                bail!("ffmpeg exited with code {}", code);
+                bail!("ffmpeg exited with {}", format_exit_status(&status));
             }
             true
         } else {
@@ -877,11 +904,11 @@ impl PipelineExecutor {
             if !errors.is_empty() {
                 bail!("vspipe failed: {}", errors.join("\n"));
             }
-            bail!("vspipe exited with code {}", vspipe_status.code().unwrap_or(-1));
+            bail!("vspipe exited with {}", format_exit_status(&vspipe_status));
         }
 
         if !output.status.success() {
-            bail!("ffmpeg encoder exited with code {}", output.status.code().unwrap_or(-1));
+            bail!("ffmpeg encoder exited with {}", format_exit_status(&output.status));
         }
 
         // Write PNG to stdout

--- a/worker/src/platform/linux.rs
+++ b/worker/src/platform/linux.rs
@@ -1,0 +1,27 @@
+//! Linux-specific functionality.
+
+use std::path::PathBuf;
+
+/// Get the user's home directory.
+#[allow(dead_code)]
+pub fn home_dir() -> Option<PathBuf> {
+    std::env::var("HOME").ok().map(PathBuf::from)
+}
+
+/// Get the application data directory (XDG_DATA_HOME/VapourBox).
+#[allow(dead_code)]
+pub fn app_data_dir() -> Option<PathBuf> {
+    if let Ok(xdg) = std::env::var("XDG_DATA_HOME") {
+        return Some(PathBuf::from(xdg).join("VapourBox"));
+    }
+    home_dir().map(|h| h.join(".local").join("share").join("VapourBox"))
+}
+
+/// Get the cache directory (XDG_CACHE_HOME/VapourBox).
+#[allow(dead_code)]
+pub fn cache_dir() -> Option<PathBuf> {
+    if let Ok(xdg) = std::env::var("XDG_CACHE_HOME") {
+        return Some(PathBuf::from(xdg).join("VapourBox"));
+    }
+    home_dir().map(|h| h.join(".cache").join("VapourBox"))
+}

--- a/worker/src/platform/mod.rs
+++ b/worker/src/platform/mod.rs
@@ -6,6 +6,9 @@ pub mod macos;
 #[cfg(target_os = "windows")]
 pub mod windows;
 
+#[cfg(target_os = "linux")]
+pub mod linux;
+
 /// Re-export platform-specific items for the current platform.
 #[cfg(target_os = "macos")]
 pub use macos::*;
@@ -13,3 +16,7 @@ pub use macos::*;
 #[cfg(target_os = "windows")]
 #[allow(unused_imports)]
 pub use windows::*;
+
+#[cfg(target_os = "linux")]
+#[allow(unused_imports)]
+pub use linux::*;


### PR DESCRIPTION
## Summary

Adds full **Linux (x86_64 + aarch64)** support to VapourBox — Flutter Linux runner, Rust worker platform layer, from-source dependency build, packaging, and CI — plus two cross-platform bug fixes discovered along the way.

Rebased onto current `main` (incl. the macOS x64 "drop Rosetta / macos-15-intel" work). Release version kept on **0.9.6** (`0.9.6+21`).

## Linux-only additions (inert on macOS/Windows)
- `.github/workflows/build-linux.yml`, `Scripts/{download-deps,package-deps,package,run-debug}-linux.sh`
- `app/linux/` Flutter runner, `worker/src/platform/linux.rs`
- Linux deps: `~/.local/share/VapourBox/deps/linux-{x64,arm64}/` (XDG-aware), `patchelf` RPATH fixups, `LD_LIBRARY_PATH` + autoload conf
- **DeScratch + TemporalMedian plugins** now built for Linux (`download-deps-linux.sh`) — these power the DeScratch and SpotLess filters, which previously failed in preview with "No attribute with the name descratch". Verified building against VS R73 and loading as `core.descratch.DeScratch` / `core.tmedian.TemporalMedian`.

## Cross-platform changes (reviewed for safety)
All additive / platform-gated — no existing macOS/Windows logic removed:
- `dependency_locator.rs`, `dependency_manager.dart`: new Linux branches; the one shared edit only adds `not(target_os = "linux")` to a cfg, leaving mac/win paths identical.
- Pre-existing shared services (`disc_detector`, `tool_locator`, `whisper_addon_manager`, `dvd_reader`) and UI handlers (`queue_panel`, `settings_dialog`): Linux branches added (`+N/-0`).
- **Bug fixes that benefit all platforms:** preview-generation race conditions (`preview_generator.dart`, `main_viewmodel.dart`); clearer process-exit errors with Unix signal names (`pipeline_executor.rs`).
- Release scripts (`release.sh`, `ci-build-and-release.sh`, `check-deps-changed.sh`) extended to build/package/upload Linux artifacts.

## Notes for reviewers
- `ci-build-and-release.sh` now watches the Linux build with `--exit-status`, so a **Linux CI failure will block the combined release upload** for all platforms.
- CI workflows are `workflow_dispatch`-only — macOS/Windows builds for this branch are triggered manually against the `linux` ref (deps tag `deps-v1.3.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)