### PR TITLE
Fix arm64 release upload in build-whisper.yml

### DIFF
--- a/.github/workflows/build-whisper.yml
+++ b/.github/workflows/build-whisper.yml
@@ -137,6 +137,9 @@ jobs:
         if: inputs.release_tag != ''
         env:
           GH_TOKEN: ${{ github.token }}
+          # These jobs do not check out the repo, so gh has no git remote to
+          # infer the repo from — set it explicitly.
+          GH_REPO: ${{ github.repository }}
         run: |
           gh release view "${{ inputs.release_tag }}" >/dev/null 2>&1 || \
             gh release create "${{ inputs.release_tag }}" \


### PR DESCRIPTION
The `GH_REPO` fix from #16 only reached the `build-x64` job; `build-arm64`'s upload step still failed with `fatal: not a git repository` (the build jobs don't `actions/checkout`, so `gh` can't infer the repo). The re-run after #16 confirmed: x64 uploaded to the release successfully, arm64 failed on this. Add `GH_REPO` to the arm64 step to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)