### PR TITLE
Show extraction progress in the deps download dialog

### DIFF
--- a/app/lib/services/dependency_manager.dart
+++ b/app/lib/services/dependency_manager.dart
@@ -422,10 +422,12 @@ class DependencyManager {
         expectedSha256: platformInfo.sha256,
       );
 
-      // Extract
+      // Extract. _extractZip emits per-file extraction progress; this initial
+      // event (0/0 -> indeterminate) covers the synchronous decode that precedes
+      // the first file write.
       _progressController.add(DownloadProgress(
-        bytesReceived: platformInfo.size ?? 0,
-        totalBytes: platformInfo.size ?? 0,
+        bytesReceived: 0,
+        totalBytes: 0,
         status: 'Extracting...',
       ));
 
@@ -528,6 +530,28 @@ class DependencyManager {
     final bytes = await zipFile.readAsBytes();
     final archive = ZipDecoder().decodeBytes(bytes);
 
+    // Total uncompressed size, for extraction progress. Extraction (many file
+    // writes + chmod) is slow on Linux, so report progress rather than leaving
+    // the dialog frozen on "Extracting...".
+    var totalBytes = 0;
+    for (final file in archive) {
+      if (file.isFile) totalBytes += file.size;
+    }
+
+    var extracted = 0;
+    var lastEmitted = -1;
+    const emitEvery = 2 * 1024 * 1024; // throttle UI updates to ~every 2 MB
+
+    void emitExtractProgress() {
+      _progressController.add(DownloadProgress(
+        bytesReceived: extracted,
+        totalBytes: totalBytes,
+        status: 'Extracting...',
+      ));
+    }
+
+    emitExtractProgress();
+
     for (final file in archive) {
       final filePath = path.join(depsDir.path, file.name);
 
@@ -540,10 +564,20 @@ class DependencyManager {
         if (!Platform.isWindows && _isExecutable(file.name)) {
           await Process.run('chmod', ['+x', filePath]);
         }
+
+        extracted += file.size;
+        if (extracted - lastEmitted >= emitEvery) {
+          lastEmitted = extracted;
+          emitExtractProgress();
+        }
       } else {
         await Directory(filePath).create(recursive: true);
       }
     }
+
+    // Final 100% extraction tick.
+    extracted = totalBytes;
+    emitExtractProgress();
 
     // On macOS, remove quarantine attribute and re-sign binaries for Gatekeeper
     if (Platform.isMacOS) {

--- a/app/lib/views/dependency_download_dialog.dart
+++ b/app/lib/views/dependency_download_dialog.dart
@@ -155,22 +155,26 @@ class _DependencyDownloadDialogState extends State<DependencyDownloadDialog> {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     Text(_progress!.status),
-                    Text(_progress!.progressPercent),
+                    if (_progress!.totalBytes > 0) Text(_progress!.progressPercent),
                   ],
                 ),
                 const SizedBox(height: 8),
                 ClipRRect(
                   borderRadius: BorderRadius.circular(4),
+                  // Indeterminate (animated) when we don't yet have a fraction —
+                  // e.g. connecting, or the zip-decode step before extraction
+                  // byte progress starts — otherwise a determinate bar.
                   child: LinearProgressIndicator(
-                    value: _progress!.progress,
+                    value: _progress!.progress > 0 ? _progress!.progress : null,
                     minHeight: 8,
                   ),
                 ),
                 const SizedBox(height: 8),
-                Text(
-                  '${_formatBytes(_progress!.bytesReceived)} / ${_formatBytes(_progress!.totalBytes)}',
-                  style: Theme.of(context).textTheme.bodySmall,
-                ),
+                if (_progress!.totalBytes > 0)
+                  Text(
+                    '${_formatBytes(_progress!.bytesReceived)} / ${_formatBytes(_progress!.totalBytes)}',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
               ] else ...[
                 const LinearProgressIndicator(),
                 const SizedBox(height: 8),


### PR DESCRIPTION
Extracting the deps zip (many file writes + chmod) is slow on Linux, and the download dialog previously sat frozen on "Extracting..." at 100% with no indication of activity.

- **`_extractZip`** now reports **per-file byte progress** (summed uncompressed total, throttled to ~every 2 MB) as it writes each entry, so the bar advances through extraction. Each write is awaited, so the UI repaints between files.
- The dialog shows an **indeterminate (animated) bar** whenever there's no fraction yet — connecting, and the synchronous zip-decode before the first file write — so there's always an activity indicator. Percent/bytes labels are hidden while the total is unknown.

Verified locally: cleared the deps cache and ran the Linux debug build — the dialog now advances through download → extraction with a live bar instead of freezing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)