### PR TITLE
Keep ffmpeg-returned encoders selectable; surface probe error as a warning (#19)

### DIFF
--- a/app/lib/services/hardware_encoder_detector.dart
+++ b/app/lib/services/hardware_encoder_detector.dart
@@ -39,6 +39,9 @@ class HardwareEncoderDetector extends ChangeNotifier {
 
   final Set<String> _compiledIn = {};
   final Map<VideoCodec, EncoderProbeState> _state = {};
+  // Error output captured from a failed functional probe, kept so the UI can
+  // surface *why* an encoder check failed (the encoder stays selectable).
+  final Map<VideoCodec, String> _probeErrors = {};
   bool _initialized = false;
 
   /// Whether the encoder is compiled into the bundled ffmpeg. Always true for
@@ -60,6 +63,10 @@ class HardwareEncoderDetector extends ChangeNotifier {
   /// or hardware codecs whose functional probe succeeded).
   bool isAvailable(VideoCodec codec) =>
       probeState(codec) == EncoderProbeState.available;
+
+  /// The error output from this codec's functional probe, if it failed. Null
+  /// when the probe passed (or hasn't run). Shown via the per-codec info button.
+  String? probeError(VideoCodec codec) => _probeErrors[codec];
 
   /// Probe the bundled ffmpeg for available encoders. Idempotent.
   Future<void> initialize() async {
@@ -119,26 +126,46 @@ class HardwareEncoderDetector extends ChangeNotifier {
   }
 
   Future<void> _probe(String ffmpegPath, VideoCodec codec) async {
+    final args = <String>[
+      '-hide_banner', '-loglevel', 'error',
+      '-f', 'lavfi', '-i', 'color=c=black:s=64x64:r=5:d=1',
+      '-frames:v', '1',
+      '-c:v', codec.value,
+      '-f', 'null', '-',
+    ];
     var ok = false;
+    String? errorLog;
     try {
       final result = await Process.run(
         ffmpegPath,
-        [
-          '-hide_banner', '-loglevel', 'error',
-          '-f', 'lavfi', '-i', 'color=c=black:s=64x64:r=5:d=1',
-          '-frames:v', '1',
-          '-c:v', codec.value,
-          '-f', 'null', '-',
-        ],
+        args,
         stdoutEncoding: const SystemEncoding(),
         stderrEncoding: const SystemEncoding(),
       );
       ok = result.exitCode == 0;
-    } catch (_) {
+      if (!ok) {
+        final err = (result.stderr as String).trim();
+        final out = (result.stdout as String).trim();
+        final detail =
+            err.isNotEmpty ? err : (out.isNotEmpty ? out : '(no output captured)');
+        errorLog = 'Probe command:\n'
+            '  ffmpeg ${args.join(' ')}\n\n'
+            'Exit code: ${result.exitCode}\n\n'
+            '$detail';
+      }
+    } catch (e) {
       ok = false;
+      errorLog = 'Probe command:\n'
+          '  ffmpeg ${args.join(' ')}\n\n'
+          'Failed to run probe: $e';
     }
     _state[codec] =
         ok ? EncoderProbeState.available : EncoderProbeState.unavailable;
+    if (errorLog != null) {
+      _probeErrors[codec] = errorLog;
+    } else {
+      _probeErrors.remove(codec);
+    }
     if (kDebugMode) {
       print('HardwareEncoderDetector: ${codec.value} -> '
           '${ok ? "available" : "unavailable"}');

--- a/app/lib/views/settings/settings_dialog.dart
+++ b/app/lib/views/settings/settings_dialog.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
 import '../../models/encoding_settings.dart';
@@ -866,24 +867,32 @@ class _OutputSettingsTabState extends State<_OutputSettingsTab> {
     final compiledIn = detector.isCompiledIn(codec);
     // Still querying whether this (compiled-in) hardware encoder works here.
     final probing = isSupported && isHw && compiledIn && detector.isProbing(codec);
-    // Usable = container-supported AND (non-hardware, or its probe succeeded).
-    final isAvailable = isSupported && detector.isAvailable(codec);
+    // The functional probe failed, but ffmpeg DID return the encoder. We keep it
+    // selectable and surface the captured error as a warning rather than blocking
+    // it — the synthetic probe can fail for encoders that still work in practice
+    // (see issue #28-adjacent reports of h264_videotoolbox being hidden).
+    final probeFailed = isSupported &&
+        isHw &&
+        compiledIn &&
+        !probing &&
+        !detector.isAvailable(codec);
+    final probeError = detector.probeError(codec);
 
-    final String? unavailableReason = !isSupported
+    // Any encoder ffmpeg returns (compiled-in) and the container supports is
+    // selectable. Only a missing build or an incompatible container blocks it.
+    final String? blockedReason = !isSupported
         ? 'Not supported in ${settings.container.name.toUpperCase()}'
-        : !compiledIn
+        : (isHw && !compiledIn)
             ? 'Not available in this build'
-            : probing
-                ? 'Checking availability…'
-                : !isAvailable
-                    ? 'Not available on this system'
-                    : null;
+            : null;
+    final clickable = blockedReason == null;
 
     final disabledStyle = TextStyle(
       color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.38),
     );
 
-    // Trailing affordance: spinner while probing, block icon when unavailable.
+    // Trailing affordance: spinner while probing; warning + info button when the
+    // probe failed (still selectable); block icon only when genuinely blocked.
     Widget? indicator;
     if (probing) {
       indicator = const Tooltip(
@@ -894,21 +903,51 @@ class _OutputSettingsTabState extends State<_OutputSettingsTab> {
           child: CircularProgressIndicator(strokeWidth: 2),
         ),
       );
-    } else if (isSupported && isHw && !isAvailable) {
+    } else if (probeFailed) {
+      indicator = Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Tooltip(
+            message: 'Availability check failed — this encoder may not work on '
+                'this system. Tap the info icon for details.',
+            child: Icon(Icons.warning_amber_rounded,
+                size: 16, color: Colors.orange[700]),
+          ),
+          IconButton(
+            icon: const Icon(Icons.info_outline, size: 16),
+            visualDensity: VisualDensity.compact,
+            padding: const EdgeInsets.only(left: 6),
+            constraints: const BoxConstraints(),
+            tooltip: 'Show availability check error',
+            onPressed: () => _showCodecProbeError(context, codec, probeError),
+          ),
+        ],
+      );
+    } else if (!clickable && isHw) {
       indicator = Tooltip(
-        message: compiledIn
-            ? 'Not available on this system'
-            : 'Not available in this build',
+        message: blockedReason,
         child: Icon(Icons.block, size: 16, color: Colors.orange[700]),
       );
+    }
+
+    final String subtitleText;
+    if (!clickable) {
+      subtitleText = blockedReason;
+    } else if (probeFailed) {
+      subtitleText =
+          'Availability check failed — selectable, but may not encode on this system.';
+    } else {
+      subtitleText = codec.description;
     }
 
     return RadioListTile<VideoCodec>(
       title: Row(
         children: [
-          Text(
-            codec.displayName,
-            style: isAvailable ? null : disabledStyle,
+          Flexible(
+            child: Text(
+              codec.displayName,
+              style: clickable ? null : disabledStyle,
+            ),
           ),
           if (indicator != null) ...[
             const SizedBox(width: 8),
@@ -917,12 +956,12 @@ class _OutputSettingsTabState extends State<_OutputSettingsTab> {
         ],
       ),
       subtitle: Text(
-        isAvailable ? codec.description : unavailableReason!,
-        style: isAvailable ? null : disabledStyle,
+        subtitleText,
+        style: clickable ? null : disabledStyle,
       ),
       value: codec,
       groupValue: settings.codec,
-      onChanged: isAvailable
+      onChanged: clickable
           ? (value) {
               if (value != null) {
                 // When switching encoder families, reset the preset to the new family's default
@@ -940,6 +979,40 @@ class _OutputSettingsTabState extends State<_OutputSettingsTab> {
               }
             }
           : null,
+    );
+  }
+
+  /// Show the captured ffmpeg error from a failed encoder availability probe.
+  Future<void> _showCodecProbeError(
+      BuildContext context, VideoCodec codec, String? error) async {
+    final text = (error == null || error.isEmpty)
+        ? 'No error output was captured for this encoder.'
+        : error;
+    await showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text('${codec.displayName} — availability check'),
+        content: SizedBox(
+          width: 560,
+          child: SingleChildScrollView(
+            child: SelectableText(
+              text,
+              style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+            ),
+          ),
+        ),
+        actions: [
+          TextButton.icon(
+            icon: const Icon(Icons.copy, size: 16),
+            label: const Text('Copy'),
+            onPressed: () => Clipboard.setData(ClipboardData(text: text)),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('Close'),
+          ),
+        ],
+      ),
     );
   }
 


### PR DESCRIPTION
## Problem
On some Intel Macs `h264_videotoolbox` was not selectable even though `ffmpeg -h encoder=h264_videotoolbox` shows it works (reported in #19).

The hardware-encoder detector runs a synthetic one-frame encode per compiled-in encoder; on any non-zero exit it marked the encoder `unavailable`, and the codec radio used `onChanged: isAvailable ? … : null` — so a failed probe **disabled** the row. That synthetic probe isn't a reliable gate, so a working encoder got hidden with no explanation.

## Change
Any encoder ffmpeg actually returns (compiled-in) and the container supports is now selectable; a failed probe is shown as a **warning, not a blocker**.

- `hardware_encoder_detector.dart` — capture the probe's stderr + exit code on failure; expose it via `probeError(codec)` (cleared on success).
- `settings_dialog.dart` — a codec row is clickable whenever it's compiled-in and container-supported (probe state no longer gates selection). A failed probe shows a ⚠️ warning icon + an ℹ️ info button that opens the captured error log (copyable). Only a missing build or an incompatible container disables a row. Spinner still shows while a probe is in flight.

## Testing
- `flutter analyze` clean (no new warnings/errors).
- Manual: a probe-failed hardware encoder is now selectable, shows the warning + info button, and the dialog displays the captured ffmpeg error.

## Scope
Addresses the "h264_videotoolbox not selectable" part of #19. The other items in that thread (HEVC `.mov` playback, HEVC quality/bitrate mapping, disappearing Copy Log button) are separate and tracked for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
