### PR TITLE
Encoding fixes (#19): Intel VideoToolbox bitrate, HEVC hvc1 tag, persistent log

### DIFF
--- a/app/lib/models/encoding_settings.dart
+++ b/app/lib/models/encoding_settings.dart
@@ -79,6 +79,11 @@ class EncodingSettings {
   final String encoderPreset;
   final int quality;
 
+  /// Target video bitrate in kbps. Used by Intel-Mac VideoToolbox (which has no
+  /// constant-quality mode), where the UI exposes a native bitrate control
+  /// instead of the CRF slider. Null for all other encoders.
+  final int? videoBitrateKbps;
+
   /// Audio handling mode.
   final AudioMode audioMode;
 
@@ -107,6 +112,7 @@ class EncodingSettings {
     this.codec = VideoCodec.h264,
     this.encoderPreset = 'medium',
     this.quality = 18,
+    this.videoBitrateKbps,
     this.audioMode = AudioMode.passthrough,
     this.audioCodec = AudioCodec.aac,
     this.audioQuality = AudioQuality.high,
@@ -189,6 +195,7 @@ class EncodingSettings {
     VideoCodec? codec,
     String? encoderPreset,
     int? quality,
+    int? videoBitrateKbps,
     AudioMode? audioMode,
     AudioCodec? audioCodec,
     AudioQuality? audioQuality,
@@ -211,6 +218,7 @@ class EncodingSettings {
       codec: codec ?? this.codec,
       encoderPreset: encoderPreset ?? this.encoderPreset,
       quality: quality ?? this.quality,
+      videoBitrateKbps: videoBitrateKbps ?? this.videoBitrateKbps,
       audioMode: effectiveAudioMode,
       audioCodec: audioCodec ?? this.audioCodec,
       audioQuality: audioQuality ?? this.audioQuality,

--- a/app/lib/views/progress_panel.dart
+++ b/app/lib/views/progress_panel.dart
@@ -158,9 +158,11 @@ class ProgressPanel extends StatelessWidget {
                 ),
               ],
 
-              // Log viewer
+              // Log viewer — keep it (and the Copy Log button) visible after a
+              // successful finish too, not just while processing/on failure.
               if (viewModel.logMessages.isNotEmpty &&
                   (state == ProcessingState.processing ||
+                      state == ProcessingState.completed ||
                       state == ProcessingState.failed)) ...[
                 const SizedBox(height: 32),
                 _buildLogViewer(context, viewModel),

--- a/app/lib/views/settings/settings_dialog.dart
+++ b/app/lib/views/settings/settings_dialog.dart
@@ -7,6 +7,7 @@ import 'package:provider/provider.dart';
 
 import '../../models/encoding_settings.dart';
 import '../../models/video_job.dart';
+import '../../services/dependency_manager.dart';
 import '../../services/hardware_encoder_detector.dart';
 import '../../services/update_checker.dart';
 import '../../viewmodels/main_viewmodel.dart';
@@ -214,11 +215,29 @@ class _OutputSettingsTabState extends State<_OutputSettingsTab> {
   late TextEditingController _filenamePatternController;
   late TextEditingController _customFfmpegArgsController;
 
+  // Intel-Mac VideoToolbox uses a native target-bitrate control (no -q:v mode).
+  final TextEditingController _vtBitrateController = TextEditingController();
+  final FocusNode _vtBitrateFocus = FocusNode();
+  late final bool _isIntelMac;
+
+  /// Default target bitrate (kbps) applied when an Intel-VT codec is selected.
+  static const int _kDefaultVtBitrateKbps = 20000;
+
+  /// Bitrate preset shortcuts (label -> Mb/s) for Intel VideoToolbox.
+  static const Map<String, int> _kVtBitratePresetsMbps = {
+    'Low': 5,
+    'Medium': 10,
+    'High': 20,
+    'Very High': 40,
+  };
+
   @override
   void initState() {
     super.initState();
     _filenamePatternController = TextEditingController();
     _customFfmpegArgsController = TextEditingController();
+    _isIntelMac = Platform.isMacOS &&
+        DependencyManager.instance.platformId == 'macos-x64';
     // Kick off (idempotent) encoder detection and rebuild as probes resolve so
     // the codec list can show/clear a busy indicator per encoder live.
     HardwareEncoderDetector.instance.addListener(_onEncoderDetectionChanged);
@@ -229,11 +248,18 @@ class _OutputSettingsTabState extends State<_OutputSettingsTab> {
     if (mounted) setState(() {});
   }
 
+  /// Whether the codec is a VideoToolbox (macOS hardware) encoder.
+  bool _isVideotoolbox(VideoCodec codec) =>
+      codec == VideoCodec.h264Videotoolbox ||
+      codec == VideoCodec.h265Videotoolbox;
+
   @override
   void dispose() {
     HardwareEncoderDetector.instance.removeListener(_onEncoderDetectionChanged);
     _filenamePatternController.dispose();
     _customFfmpegArgsController.dispose();
+    _vtBitrateController.dispose();
+    _vtBitrateFocus.dispose();
     super.dispose();
   }
 
@@ -500,40 +526,16 @@ class _OutputSettingsTabState extends State<_OutputSettingsTab> {
             if (settings.codec.availablePresets != null)
               const SizedBox(height: 24),
 
-            // Quality (not applicable for lossless codecs)
+            // Quality (not applicable for lossless codecs). Intel VideoToolbox has
+            // no constant-quality mode, so it gets a native target-bitrate control
+            // instead of the CRF slider.
             if (!settings.codec.isLossless)
               _buildSection(
                 context,
                 title: 'Quality',
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Slider(
-                      value: settings.quality.toDouble(),
-                      min: 0,
-                      max: 51,
-                      divisions: 51,
-                      label: settings.qualityDescription,
-                      onChanged: (value) {
-                        viewModel.updateEncodingSettings(
-                            settings.copyWith(quality: value.round()));
-                      },
-                    ),
-                    Text(
-                      settings.qualityDescription,
-                      style: Theme.of(context).textTheme.bodyMedium,
-                    ),
-                    Text(
-                      'Lower values = higher quality, larger file',
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color: Theme.of(context)
-                                .colorScheme
-                                .onSurface
-                                .withValues(alpha: 0.6),
-                          ),
-                    ),
-                  ],
-                ),
+                child: (_isIntelMac && _isVideotoolbox(settings.codec))
+                    ? _buildVideotoolboxBitrate(context, viewModel, settings)
+                    : _buildCrfQuality(context, viewModel, settings),
               ),
 
             // Note for lossless codec
@@ -859,6 +861,105 @@ class _OutputSettingsTabState extends State<_OutputSettingsTab> {
     );
   }
 
+  /// The standard CRF/quality slider (software, NVENC, QSV, AMF, Apple-Silicon VT).
+  Widget _buildCrfQuality(
+      BuildContext context, MainViewModel viewModel, EncodingSettings settings) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Slider(
+          value: settings.quality.toDouble(),
+          min: 0,
+          max: 51,
+          divisions: 51,
+          label: settings.qualityDescription,
+          onChanged: (value) {
+            viewModel.updateEncodingSettings(
+                settings.copyWith(quality: value.round()));
+          },
+        ),
+        Text(
+          settings.qualityDescription,
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        Text(
+          'Lower values = higher quality, larger file',
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color:
+                    Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+              ),
+        ),
+      ],
+    );
+  }
+
+  /// Native Intel-VideoToolbox control: target average bitrate (preset chips +
+  /// an editable Mb/s field). Intel VT has no constant-quality (-q:v) mode.
+  Widget _buildVideotoolboxBitrate(
+      BuildContext context, MainViewModel viewModel, EncodingSettings settings) {
+    final currentKbps = settings.videoBitrateKbps ?? _kDefaultVtBitrateKbps;
+    // Sync the field when the value changes via a preset chip or codec switch,
+    // but never clobber what the user is actively typing.
+    final mbpsText =
+        (currentKbps / 1000).toString().replaceAll(RegExp(r'\.0$'), '');
+    if (!_vtBitrateFocus.hasFocus && _vtBitrateController.text != mbpsText) {
+      _vtBitrateController.text = mbpsText;
+    }
+
+    void setKbps(int kbps) {
+      viewModel
+          .updateEncodingSettings(settings.copyWith(videoBitrateKbps: kbps));
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: _kVtBitratePresetsMbps.entries.map((e) {
+            final kbps = e.value * 1000;
+            return ChoiceChip(
+              label: Text('${e.key} (${e.value} Mb/s)'),
+              selected: currentKbps == kbps,
+              onSelected: (_) => setKbps(kbps),
+            );
+          }).toList(),
+        ),
+        const SizedBox(height: 12),
+        SizedBox(
+          width: 220,
+          child: TextField(
+            controller: _vtBitrateController,
+            focusNode: _vtBitrateFocus,
+            keyboardType:
+                const TextInputType.numberWithOptions(decimal: true),
+            decoration: const InputDecoration(
+              labelText: 'Target bitrate',
+              suffixText: 'Mb/s',
+              border: OutlineInputBorder(),
+            ),
+            onChanged: (value) {
+              final mbps = double.tryParse(value.trim());
+              if (mbps != null && mbps > 0) {
+                setKbps((mbps * 1000).round());
+              }
+            },
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'VideoToolbox on Intel Macs encodes to a target average bitrate '
+          '(no constant-quality mode). Higher = better quality, larger file.',
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color:
+                    Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+              ),
+        ),
+      ],
+    );
+  }
+
   Widget _buildCodecRadio(BuildContext context, MainViewModel viewModel,
       EncodingSettings settings, VideoCodec codec) {
     final detector = HardwareEncoderDetector.instance;
@@ -964,16 +1065,26 @@ class _OutputSettingsTabState extends State<_OutputSettingsTab> {
       onChanged: clickable
           ? (value) {
               if (value != null) {
+                // Seed a default target bitrate when switching to an Intel-VT
+                // codec so the worker uses it instead of the low fallback estimate.
+                final vtBitrate = (_isIntelMac &&
+                        _isVideotoolbox(value) &&
+                        settings.videoBitrateKbps == null)
+                    ? _kDefaultVtBitrateKbps
+                    : settings.videoBitrateKbps;
                 // When switching encoder families, reset the preset to the new family's default
                 final oldFamily = settings.codec.encoderFamily;
                 final newFamily = value.encoderFamily;
                 if (oldFamily != newFamily) {
                   viewModel.updateEncodingSettings(
-                    settings.copyWith(codec: value, encoderPreset: value.defaultPreset),
+                    settings.copyWith(
+                        codec: value,
+                        encoderPreset: value.defaultPreset,
+                        videoBitrateKbps: vtBitrate),
                   );
                 } else {
                   viewModel.updateEncodingSettings(
-                    settings.copyWith(codec: value),
+                    settings.copyWith(codec: value, videoBitrateKbps: vtBitrate),
                   );
                 }
               }

--- a/worker/src/models/video_job.rs
+++ b/worker/src/models/video_job.rs
@@ -152,6 +152,13 @@ pub struct EncodingSettings {
     /// Output container format
     #[serde(default)]
     pub container: ContainerFormat,
+
+    /// Target video bitrate in kbps. Used by Intel-Mac VideoToolbox (which has no
+    /// constant-quality mode), where the UI exposes a native bitrate control
+    /// instead of the CRF slider. `None` falls back to a resolution-derived
+    /// estimate; ignored by all other encoder families.
+    #[serde(default)]
+    pub video_bitrate_kbps: Option<u32>,
 }
 
 fn default_encoder_preset() -> String {
@@ -313,6 +320,7 @@ impl Default for EncodingSettings {
             chroma_subsampling: ChromaSubsampling::default(),
             custom_ffmpeg_args: String::new(),
             container: ContainerFormat::default(),
+            video_bitrate_kbps: None,
         }
     }
 }

--- a/worker/src/pipeline_executor.rs
+++ b/worker/src/pipeline_executor.rs
@@ -661,6 +661,17 @@ impl PipelineExecutor {
             args.extend(["-pix_fmt".to_string(), pix_fmt.to_string()]);
         }
 
+        // MP4/MOV container fixups. QuickTime and other Apple players reject HEVC
+        // with the default `hev1` sample-entry; force `hvc1` so the output is
+        // playable. Also move the moov atom to the front (+faststart) for better
+        // playback/seeking. Both are no-ops for MKV/AVI.
+        if matches!(settings.container, ContainerFormat::Mp4 | ContainerFormat::Mov) {
+            if settings.codec.is_h265() {
+                args.extend(["-tag:v".to_string(), "hvc1".to_string()]);
+            }
+            args.extend(["-movflags".to_string(), "+faststart".to_string()]);
+        }
+
         // Preserve input sample aspect ratio (SAR) when no resize is applied.
         // The Y4M pipe from vspipe strips SAR metadata, so we must re-apply it.
         let pipeline = job.effective_pipeline();
@@ -802,7 +813,13 @@ impl PipelineExecutor {
                     }
                     #[cfg(not(target_arch = "aarch64"))]
                     {
-                        let kbps = Self::videotoolbox_bitrate_kbps(job);
+                        // Native Intel-VideoToolbox control: an explicit target
+                        // bitrate set in the UI. Fall back to the resolution-derived
+                        // estimate only when the UI didn't provide one.
+                        let kbps = settings
+                            .video_bitrate_kbps
+                            .filter(|&k| k > 0)
+                            .unwrap_or_else(|| Self::videotoolbox_bitrate_kbps(job));
                         args.extend(["-b:v".to_string(), format!("{}k", kbps)]);
                     }
                 }
@@ -1064,6 +1081,15 @@ mod tests {
             args.extend(["-pix_fmt".to_string(), pix_fmt.to_string()]);
         }
 
+        // MP4/MOV container fixups (mirrors build_ffmpeg_args): hvc1 tag for HEVC
+        // so Apple players accept it, plus +faststart.
+        if matches!(settings.container, ContainerFormat::Mp4 | ContainerFormat::Mov) {
+            if settings.codec.is_h265() {
+                args.extend(["-tag:v".to_string(), "hvc1".to_string()]);
+            }
+            args.extend(["-movflags".to_string(), "+faststart".to_string()]);
+        }
+
         // Audio handling
         match settings.audio_mode {
             AudioMode::Passthrough => {
@@ -1136,6 +1162,65 @@ mod tests {
 
         // Unknown codecs are excluded (allowlist) to avoid a hard encode failure.
         assert!(!PipelineExecutor::is_text_subtitle("some_future_codec"));
+    }
+
+    /// True if `args` contains the consecutive pair [flag, value].
+    fn has_arg_pair(args: &[String], flag: &str, value: &str) -> bool {
+        args.windows(2).any(|w| w[0] == flag && w[1] == value)
+    }
+
+    #[test]
+    fn test_hevc_mp4_tagged_hvc1_for_quicktime() {
+        // Issue #19: HEVC in MP4/MOV must use the hvc1 sample-entry tag or Apple
+        // players (QuickTime) reject the file.
+        let mut job = create_test_job("out.mp4");
+        job.encoding_settings.codec = VideoCodec::H265;
+        job.encoding_settings.container = ContainerFormat::Mp4;
+        let args = build_ffmpeg_args_for_test(&job);
+        assert!(has_arg_pair(&args, "-tag:v", "hvc1"), "HEVC/MP4 must set -tag:v hvc1: {args:?}");
+        assert!(has_arg_pair(&args, "-movflags", "+faststart"), "MP4 should set +faststart");
+    }
+
+    #[test]
+    fn test_hevc_mov_tagged_hvc1() {
+        let mut job = create_test_job("out.mov");
+        job.encoding_settings.codec = VideoCodec::H265Videotoolbox;
+        job.encoding_settings.container = ContainerFormat::Mov;
+        let args = build_ffmpeg_args_for_test(&job);
+        assert!(has_arg_pair(&args, "-tag:v", "hvc1"), "HEVC/MOV must set -tag:v hvc1");
+    }
+
+    #[test]
+    fn test_h264_mp4_not_tagged_hvc1() {
+        let mut job = create_test_job("out.mp4");
+        job.encoding_settings.codec = VideoCodec::H264;
+        job.encoding_settings.container = ContainerFormat::Mp4;
+        let args = build_ffmpeg_args_for_test(&job);
+        assert!(!has_arg_pair(&args, "-tag:v", "hvc1"), "H.264 must not be tagged hvc1");
+        assert!(has_arg_pair(&args, "-movflags", "+faststart"));
+    }
+
+    #[test]
+    fn test_hevc_mkv_no_hvc1_or_faststart() {
+        let mut job = create_test_job("out.mkv");
+        job.encoding_settings.codec = VideoCodec::H265;
+        job.encoding_settings.container = ContainerFormat::Mkv;
+        let args = build_ffmpeg_args_for_test(&job);
+        assert!(!has_arg_pair(&args, "-tag:v", "hvc1"), "MKV doesn't use hvc1");
+        assert!(!has_arg_pair(&args, "-movflags", "+faststart"), "faststart is MP4/MOV-only");
+    }
+
+    // Intel-only: VideoToolbox uses an explicit target bitrate (no constant-quality
+    // mode). On Apple Silicon the encoder uses -q:v, so this assertion is x86_64-only.
+    #[cfg(not(target_arch = "aarch64"))]
+    #[test]
+    fn test_videotoolbox_intel_uses_explicit_bitrate() {
+        let mut job = create_test_job("out.mp4");
+        job.encoding_settings.codec = VideoCodec::H265Videotoolbox;
+        job.encoding_settings.container = ContainerFormat::Mp4;
+        job.encoding_settings.video_bitrate_kbps = Some(20000);
+        let args = build_ffmpeg_args_for_test(&job);
+        assert!(has_arg_pair(&args, "-b:v", "20000k"), "Intel VT must use the chosen bitrate: {args:?}");
     }
 
     #[test]


### PR DESCRIPTION
Follow-up fixes for issue #19 (rebased onto main after #29 merged).

## #3 — VideoToolbox quality (Intel Macs)
Intel VideoToolbox has no constant-quality (`-q:v`) mode, so the CRF slider was mapped through a too-low bits-per-pixel estimate (SD HEVC @ Q0 ≈ 1.2 Mb/s). Now the **native control** is shown: a new optional `videoBitrateKbps` setting; on Intel the Quality section renders **bitrate presets (Low/Medium/High/Very High) + an editable Mb/s field** and the worker emits `-b:v` from it (estimate only as fallback). Selecting an Intel-VT codec seeds a 20 Mb/s default. Apple Silicon unchanged (native `-q:v`).

## #2 — HEVC `.mov`/`.mp4` won't play in QuickTime
Emit `-tag:v hvc1` for HEVC in MP4/MOV (Apple players reject `hev1`) + `-movflags +faststart`. No-op for MKV/AVI and non-HEVC.

## #4 — Copy Log button disappears on finish
Log panel now also shows on `completed`, so the log + Copy button remain after a successful run.

## Testing
- `cargo test` — new worker tests (hvc1 present for HEVC+mp4/mov, absent for h264, none for mkv; Intel-VT `-b:v` path). 62 lib tests pass.
- `flutter analyze` clean. `videoBitrateKbps` nullable/optional, round-trips Dart↔Rust, ignored by non-VideoToolbox codecs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
