### PR TITLE
Make Flutter integration tests run headless in CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,21 +1,18 @@
-name: CI Tests
+name: Nightly Integration Tests
 
-# Pulls the published dependency bundle + the whisper add-on (binary + small
-# model) and runs the Rust test suite plus the Flutter tests, EXCLUDING the
-# heavy full-encode integration tests (those run in nightly.yml via
-# `--tags heavy`). macOS is tested natively on both arm64 (macos-15) and x64
-# (macos-15-intel); Windows on x64; Linux on x64 (ubuntu-22.04).
+# Runs the heavy, full-encode Flutter integration tests (tagged `heavy`) that are
+# excluded from the per-push CI gate (ci-test.yml). These run the worker
+# end-to-end through `vspipe | ffmpeg` for every pipeline pass and verify real
+# output properties (codecs, field order, audio streams, pixel format, trimming,
+# subtitles). Same 4-platform matrix and deps/whisper provisioning as ci-test.yml.
 
 on:
-  push:
-    branches: [main]
-    paths-ignore: ['**.md', 'docs/**', 'licenses/**']
-  pull_request:
-    paths-ignore: ['**.md', 'docs/**', 'licenses/**']
+  schedule:
+    - cron: '0 7 * * *'  # 07:00 UTC daily
   workflow_dispatch:
 
 concurrency:
-  group: ci-test-${{ github.ref }}
+  group: nightly-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -33,8 +30,6 @@ jobs:
             runner: macos-15-intel  # last native Intel image, available until ~Aug 2027
     runs-on: ${{ matrix.runner }}
     env:
-      # Point the Flutter ToolLocator/DependencyManager at the repo-root deps
-      # (Platform.resolvedExecutable is the test runner under `flutter test`).
       VAPOURBOX_DEPS_DIR: ${{ github.workspace }}/deps/macos-${{ matrix.arch }}
     steps:
       - uses: actions/checkout@v4
@@ -67,7 +62,6 @@ jobs:
           rm -f "$ZIP"
           xattr -cr deps/macos-${{ matrix.arch }} 2>/dev/null || true
 
-      # The whisper small model (~466 MB) is architecture-independent; cache it.
       - name: Cache whisper model
         uses: actions/cache@v4
         with:
@@ -78,20 +72,16 @@ jobs:
         run: |
           mkdir -p .whisper-cache addons/whisper/models
           if [ ! -f .whisper-cache/ggml-small.bin ]; then
-            echo "Downloading whisper small model..."
             curl -L -o .whisper-cache/ggml-small.bin "$WHISPER_MODEL_URL"
           fi
           cp .whisper-cache/ggml-small.bin addons/whisper/models/ggml-small.bin
-          # whisper-cli comes from the same Homebrew bottle the app downloads.
           brew install whisper-cpp
           BP="$(brew --prefix)"
           ln -sfn "$BP/opt/whisper-cpp/bin" addons/whisper/bin
           ln -sfn "$BP/opt/whisper-cpp/lib" addons/whisper/lib
 
-      - name: Rust tests
-        # Debug build: DependencyLocator's upward search then finds the repo-root
-        # deps/ and addons/ (release mode looks under ~/Library).
-        run: cd worker && cargo test -- --nocapture
+      - name: Build worker (debug)
+        run: cd worker && cargo build
 
       - name: Generate Dart serialization
         run: |
@@ -99,10 +89,8 @@ jobs:
           flutter pub get
           dart run build_runner build --delete-conflicting-outputs
 
-      - name: Flutter tests
-        # Excludes @Tags(['heavy']) — the full-encode integration tests, which
-        # run in nightly.yml. The script-only integration tests + unit tests run here.
-        run: cd app && flutter test --exclude-tags heavy
+      - name: Heavy integration tests
+        run: cd app && flutter test --tags heavy
 
   windows:
     runs-on: windows-latest
@@ -137,8 +125,6 @@ jobs:
           ZIP="VapourBox-deps-${VER}-windows-x64.zip"
           mkdir -p deps/windows-x64
           gh release download "${{ steps.deps.outputs.tag }}" --pattern "$ZIP" --dir . --clobber
-          # The Windows deps zip uses backslash separators; 7-Zip handles that
-          # (info-zip `unzip` warns and exits non-zero, tripping `set -e`).
           7z x "$ZIP" -o"deps/windows-x64" -y >/dev/null
           rm -f "$ZIP"
 
@@ -159,14 +145,12 @@ jobs:
           curl -L -o /tmp/whisper-win.zip \
             "https://github.com/ggml-org/whisper.cpp/releases/download/v1.8.3/whisper-bin-x64.zip"
           7z x /tmp/whisper-win.zip -o/tmp/whisper-win -y >/dev/null
-          # Flatten: DependencyLocator expects addons/whisper/whisper-cli.exe
           CLI=$(find /tmp/whisper-win -name "whisper-cli.exe" | head -1)
           cp "$(dirname "$CLI")"/*.exe addons/whisper/ 2>/dev/null || true
           cp "$(dirname "$CLI")"/*.dll addons/whisper/ 2>/dev/null || true
-          ls addons/whisper/
 
-      - name: Rust tests
-        run: cd worker && cargo test -- --nocapture
+      - name: Build worker (debug)
+        run: cd worker && cargo build
 
       - name: Generate Dart serialization
         run: |
@@ -174,16 +158,12 @@ jobs:
           flutter pub get
           dart run build_runner build --delete-conflicting-outputs
 
-      - name: Flutter tests
-        # Excludes @Tags(['heavy']) — the full-encode integration tests, which
-        # run in nightly.yml. The script-only integration tests + unit tests run here.
-        run: cd app && flutter test --exclude-tags heavy
+      - name: Heavy integration tests
+        run: cd app && flutter test --tags heavy
 
   linux:
-    runs-on: ubuntu-22.04  # matches the deps-build runner (glibc compatibility)
+    runs-on: ubuntu-22.04
     env:
-      # Dart ToolLocator/DependencyManager honour this; the Rust locator does
-      # not (it uses the XDG path), so we also symlink it below.
       VAPOURBOX_DEPS_DIR: ${{ github.workspace }}/deps/linux-x64
     steps:
       - uses: actions/checkout@v4
@@ -231,32 +211,22 @@ jobs:
         run: |
           mkdir -p .whisper-cache addons/whisper/models addons/whisper/bin
           if [ ! -f .whisper-cache/ggml-small.bin ]; then
-            echo "Downloading whisper small model..."
             curl -L -o .whisper-cache/ggml-small.bin "$WHISPER_MODEL_URL"
           fi
           cp .whisper-cache/ggml-small.bin addons/whisper/models/ggml-small.bin
-          # Download the same published whisper-cli the app fetches at runtime
-          # (the linux-x64 source in whisper-addon.json), so the test exercises
-          # the real add-on artifact + tar layout instead of building from
-          # source. Mirrors the Windows job, which curls its release zip.
           WHISPER_URL=$(python3 -c "import json;print(json.load(open('app/assets/whisper-addon.json'))['binary']['platforms']['linux-x64']['url'])")
-          echo "whisper-cli: $WHISPER_URL"
           curl -L -o /tmp/whisper-cli.tar.gz "$WHISPER_URL"
-          tar xzf /tmp/whisper-cli.tar.gz -C addons/whisper  # => addons/whisper/bin/whisper-cli
+          tar xzf /tmp/whisper-cli.tar.gz -C addons/whisper
           chmod +x addons/whisper/bin/whisper-cli
-          ls -la addons/whisper/bin addons/whisper/models
 
       - name: Stage deps/addons at XDG path for the Rust locator
-        # The Rust DependencyLocator on Linux only looks under
-        # ~/.local/share/VapourBox (no debug upward-search); the Dart tests use
-        # the repo-root copy. Symlink so a single checkout satisfies both.
         run: |
           mkdir -p "$HOME/.local/share/VapourBox"
           ln -sfn "${{ github.workspace }}/deps" "$HOME/.local/share/VapourBox/deps"
           ln -sfn "${{ github.workspace }}/addons" "$HOME/.local/share/VapourBox/addons"
 
-      - name: Rust tests
-        run: cd worker && cargo test -- --nocapture
+      - name: Build worker (debug)
+        run: cd worker && cargo build
 
       - name: Generate Dart serialization
         run: |
@@ -264,7 +234,5 @@ jobs:
           flutter pub get
           dart run build_runner build --delete-conflicting-outputs
 
-      - name: Flutter tests
-        # Excludes @Tags(['heavy']) — the full-encode integration tests, which
-        # run in nightly.yml. The script-only integration tests + unit tests run here.
-        run: cd app && flutter test --exclude-tags heavy
+      - name: Heavy integration tests
+        run: cd app && flutter test --tags heavy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,7 +297,13 @@ Adding a filter touches many files. Missing any step causes silent failures (fil
 - If the plugin only supports 8-bit, add bit-depth conversion guard in templates
 - If the plugin fails on field-based clips, note this — the preview template conditionally sets field-based via `{{#SET_FIELD_BASED}}` (only when deinterlacing is enabled)
 
-**9. Integration Test** — required (see below)
+**9. Integration Tests** — required, BOTH suites (see "Integration Tests for Filter Changes" below):
+- Add a numbered Rust test in `worker/tests/filter_integration_test.rs`.
+- Update the Flutter integration tests in `app/test/integration_*_test.dart`: add
+  script-generation param coverage to `integration_filter_parameters_test.dart`
+  (assert the new pass's call + key params appear in the generated `.vpy`), and a
+  full-encode smoke test for the new pass in `integration_new_passes_test.dart`
+  (or another `@Tags(['heavy'])` file). These now run in CI.
 
 **10. Plugin Binaries**
 - Add a download/build block to each `Scripts/download-deps-*` script (deps
@@ -326,7 +332,26 @@ Adding a filter touches many files. Missing any step causes silent failures (fil
 
 ### Integration Tests for Filter Changes (Required)
 
-**Every filter addition or parameter change must include an integration test** in `worker/tests/filter_integration_test.rs`. Tests are numbered sequentially (e.g., `test_50_chroma_shift`).
+**Every filter addition or parameter change must update BOTH integration suites — they both run in CI:**
+
+1. **Rust** — a numbered test in `worker/tests/filter_integration_test.rs` (patterns below).
+2. **Flutter** — `app/test/integration_*_test.dart`:
+   - Add script-generation coverage to `integration_filter_parameters_test.dart`
+     (or `integration_qtgmc_parameters_test.dart` for QTGMC): enable the pass with
+     explicit non-default values and assert its VapourSynth call + those params
+     appear in the generated `.vpy` (see the `descratch`/`spotless` tests for the
+     pattern). These are script-only (no encode) and run in the **per-push gate**.
+   - Add a full-encode smoke test in `integration_new_passes_test.dart` (or another
+     `@Tags(['heavy'])` file): run the worker end-to-end and assert a valid output
+     (e.g. via `WorkerHarness.firstStream`). `heavy` tests run in **nightly.yml**,
+     not the push gate.
+
+All Flutter integration tests share `app/test/support/worker_harness.dart`, which
+resolves the worker + deps cross-platform and **downloads the pinned deps release
+if `deps/<platform>` is absent** (honoring `$VAPOURBOX_DEPS_DIR`). Call
+`await WorkerHarness.ensureReady()` in `setUpAll`.
+
+**Rust patterns** — every filter/parameter change must include a numbered test in `worker/tests/filter_integration_test.rs` (e.g., `test_50_chroma_shift`).
 
 Two test patterns are used:
 
@@ -444,31 +469,31 @@ cd worker && cargo test --test subtitle_integration_test -- --nocapture
 ### 2. Flutter `test/` suite — `app/test/`, run by `flutter test`  ← the CI gate
 
 ```bash
-cd app && flutter test
+cd app && flutter test --exclude-tags heavy   # what the push gate runs
+cd app && flutter test                          # everything, incl. heavy (local)
 ```
 
-Headless Dart-VM tests. A mix of pure unit tests (`dynamic_parameters`,
-`filter_schema`, `parameter_converter`, `widget_test`, `scan_type_detection`)
-and integration-style tests that shell out to the bundled binaries
-(`vapoursynth_integration_test`, `schema_converter_integration_test`); the latter
-need the per-arch `deps/` and (for whisper) `addons/`. **This is the Flutter
-suite CI runs** — put new shell-out Dart tests here so CI covers them.
+Headless Dart-VM tests. Three groups:
+- **Pure unit tests** — `dynamic_parameters`, `filter_schema`,
+  `parameter_converter`, `widget_test`, `scan_type_detection`.
+- **Shell-out tests** — `vapoursynth_integration_test`,
+  `schema_converter_integration_test`; need the per-arch `deps/` and (for whisper)
+  `addons/`.
+- **Integration tests** — `integration_*_test.dart` (formerly the standalone
+  `integration_test/` suite, now headless + cross-platform). They spawn the
+  worker end-to-end via `app/test/support/worker_harness.dart`. The encode-heavy
+  ones are `@Tags(['heavy'])`: the **push gate** runs `--exclude-tags heavy`
+  (script-only: `integration_filter_parameters_test`,
+  `integration_qtgmc_parameters_test`); **nightly.yml** runs `--tags heavy`
+  (`integration_filter_pipeline`, `_audio_conversion`, `_chroma_subsampling`,
+  `_interlacing_status`, `_video_trimming`, `_new_passes`).
 
-### 3. Flutter `integration_test/` suite — `app/integration_test/`, NOT in CI
-
-```bash
-cd app && flutter test integration_test   # separate invocation; needs a display/device
-```
-
-- Flutter routes **anything** under `integration_test/` through the device
-  launcher (even plain `package:test` files), so it can't be combined with the
-  `test/` suite in one `flutter test` call and won't run on a headless CI runner
-  without a display (e.g. `xvfb`). These are **local/manual** tests.
-- **Not maintained by CI, so they drift.** As of this writing
-  `filter_pipeline_test.dart` is stale and does not compile — it references a
-  removed API (`EncodingSettings.audioCopy`, now the `AudioMode` enum;
-  `ChromaFixParameters.vinverseScl`, now `vinverseSstr`/`vinverseAmnt`). Fix or
-  delete before relying on it; prefer adding shell-out tests to suite #2 instead.
+The harness honors `$VAPOURBOX_DEPS_DIR`, else uses repo-root `deps/<platform>`,
+else **downloads the deps release pinned in `app/assets/deps-version.json`**
+(opt out with `$VAPOURBOX_SKIP_DEPS_DOWNLOAD=1`). The worker binary is found under
+`worker/target/{release,debug}` (CI's `cargo test`/`cargo build` produces debug).
+Subtitle heavy tests skip when the whisper add-on is absent. Put new shell-out or
+integration Dart tests here so CI covers them; tag full-encode tests `heavy`.
 
 ```bash
 # Run the worker standalone (no test harness)
@@ -479,8 +504,9 @@ cd worker && cargo run --release -- --config test_job.json
 
 Runs on push to `main` + PRs (skipped for doc-only changes via `paths-ignore`).
 Each job pulls the published deps bundle + the whisper add-on, then runs
-**suite #1 (`cargo test`) and suite #2 (`flutter test`)** — including the subtitle
-integration test. Matrix: macOS **arm64** (`macos-15`), macOS **x64**
+**suite #1 (`cargo test`) and suite #2 (`flutter test --exclude-tags heavy`)** —
+including the subtitle integration test, excluding the heavy full-encode
+integration tests. Matrix: macOS **arm64** (`macos-15`), macOS **x64**
 (`macos-15-intel`), **Windows x64**, **Linux x64** (`ubuntu-22.04`). Notes:
 
 - whisper-cli is provisioned from the **same source the app uses at runtime**
@@ -489,7 +515,9 @@ integration test. Matrix: macOS **arm64** (`macos-15`), macOS **x64**
   built by `build-whisper.yml`).
 - Fixtures (`small_clip.mp4`, telecine/interlaced clips) are committed under
   `Tests/TestResources/`.
-- Suite #3 (`integration_test/`) is **not** part of this gate (see above).
+- The heavy full-encode integration tests (`@Tags(['heavy'])`) are **not** in this
+  gate — they run in `.github/workflows/nightly.yml` (cron + `workflow_dispatch`)
+  via `flutter test --tags heavy` on the same 4-platform matrix.
 
 ## Code Style
 

--- a/app/dart_test.yaml
+++ b/app/dart_test.yaml
@@ -1,0 +1,9 @@
+# Test tag declarations for `flutter test`.
+#
+# The `heavy` tag marks full-encode integration tests (test/integration_*_test.dart
+# that run the worker end-to-end through vspipe | ffmpeg). They are slow, so the
+# per-push CI gate runs `flutter test --exclude-tags heavy` and the nightly
+# workflow runs `flutter test --tags heavy`. Run them locally with either filter.
+tags:
+  heavy:
+    # Full-encode integration tests — run nightly, excluded from the push gate.

--- a/app/test/integration_audio_conversion_test.dart
+++ b/app/test/integration_audio_conversion_test.dart
@@ -2,41 +2,36 @@
 /// These tests verify that all audio modes (passthrough, convert, none) and
 /// all audio codecs (AAC, MP3, AC-3, FLAC, Opus, PCM) work correctly.
 ///
-/// Run with: flutter test integration_test/audio_conversion_test.dart
-/// Or: dart test integration_test/audio_conversion_test.dart --chain-stack-traces
+/// Run headless via CI: flutter test test/integration_audio_conversion_test.dart
+/// Heavy (full-encode) — tagged so it runs in the nightly workflow, not the push gate.
+@Tags(['heavy'])
+library;
+
+// ignore_for_file: avoid_print — these tests print diagnostics to the test log.
 
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:uuid/uuid.dart';
 
-import '../lib/models/encoding_settings.dart';
-import '../lib/models/qtgmc_parameters.dart';
-import '../lib/models/processing_pipeline.dart';
-import '../lib/models/video_job.dart';
+import 'package:vapourbox/models/encoding_settings.dart';
+import 'package:vapourbox/models/qtgmc_parameters.dart';
+import 'package:vapourbox/models/processing_pipeline.dart';
+import 'package:vapourbox/models/video_job.dart';
 
-/// Test configuration
+import 'support/worker_harness.dart';
+
+/// Thin shim over [WorkerHarness] so the test bodies keep their `TestConfig.*`
+/// call sites while paths/env resolve cross-platform.
 class TestConfig {
-  static final String projectRoot = _findProjectRoot();
-  static String get inputFile => '$projectRoot/Tests/TestResources/interlaced_test.avi';
-  static String get outputDir => '$projectRoot/Tests/TestOutput/audio';
-  static String get workerPath => '$projectRoot/worker/target/release/vapourbox-worker.exe';
-  static String get depsDir => '$projectRoot/deps/windows-x64';
-
-  static String _findProjectRoot() {
-    var dir = Directory.current;
-    while (!File('${dir.path}/CLAUDE.md').existsSync()) {
-      final parent = dir.parent;
-      if (parent.path == dir.path) {
-        throw StateError('Could not find project root (looking for CLAUDE.md)');
-      }
-      dir = parent;
-    }
-    return dir.path.replaceAll('\\', '/');
-  }
+  static String get projectRoot => WorkerHarness.repoRoot;
+  static String get inputFile => WorkerHarness.inputFile;
+  static String get outputDir => '${WorkerHarness.outputDir}/audio';
+  static String get workerPath => WorkerHarness.workerPath;
+  static String get depsDir => WorkerHarness.depsDir;
 }
 
 // =============================================================================
@@ -71,7 +66,7 @@ class AudioStreamInfo {
 
 /// Get detailed information about audio streams in a video file using ffprobe
 Future<AudioStreamInfo> getAudioStreamInfo(String videoPath) async {
-  final ffprobePath = '${TestConfig.depsDir}/ffmpeg/ffprobe.exe';
+  final ffprobePath = WorkerHarness.ffprobePath;
 
   final result = await Process.run(
     ffprobePath,
@@ -83,7 +78,7 @@ Future<AudioStreamInfo> getAudioStreamInfo(String videoPath) async {
       videoPath,
     ],
     environment: {
-      'PATH': '${TestConfig.depsDir}/ffmpeg;${Platform.environment['PATH']}',
+      'PATH': '${WorkerHarness.depsDir}/ffmpeg${Platform.isWindows ? ';' : ':'}${Platform.environment['PATH']}',
     },
   );
 
@@ -112,7 +107,7 @@ Future<AudioStreamInfo> getAudioStreamInfo(String videoPath) async {
 /// Extract raw audio from a video file as PCM WAV for binary comparison
 /// Returns the MD5 hash of the audio data, or null if no audio
 Future<String?> extractAudioHash(String videoPath) async {
-  final ffmpegPath = '${TestConfig.depsDir}/ffmpeg/ffmpeg.exe';
+  final ffmpegPath = WorkerHarness.ffmpegPath;
   final tempDir = Directory.systemTemp;
   final audioPath = '${tempDir.path}/audio_${DateTime.now().millisecondsSinceEpoch}.wav';
 
@@ -130,7 +125,7 @@ Future<String?> extractAudioHash(String videoPath) async {
         audioPath,
       ],
       environment: {
-        'PATH': '${TestConfig.depsDir}/ffmpeg;${Platform.environment['PATH']}',
+        'PATH': '${WorkerHarness.depsDir}/ffmpeg${Platform.isWindows ? ';' : ':'}${Platform.environment['PATH']}',
       },
     );
 
@@ -189,14 +184,8 @@ Future<FilterTestResult> runFilterTest(String testName, VideoJob job, {
   final configFile = File('${Directory.systemTemp.path}/job_${job.id}.json');
   await configFile.writeAsString(jsonEncode(job.toJson()));
 
-  // Set up environment
-  final env = Map<String, String>.from(Platform.environment);
-  final depsDir = TestConfig.depsDir;
-
-  env['PYTHONHOME'] = '$depsDir/vapoursynth';
-  env['PYTHONPATH'] = '$depsDir/vapoursynth/Lib/site-packages';
-  env['PATH'] = '$depsDir/vapoursynth;$depsDir/ffmpeg;${env['PATH']}';
-  env['VAPOURSYNTH_PLUGIN_PATH'] = '$depsDir/vapoursynth/vs-plugins';
+  // Cross-platform worker environment sourced from the shared harness.
+  final env = WorkerHarness.workerEnv;
 
   try {
     print('\n${'=' * 60}');
@@ -339,33 +328,8 @@ VideoJob createAudioTestJob(String outputPath, EncodingSettings settings) {
 void main() {
   // Ensure output directory exists
   setUpAll(() async {
-    final outputDir = Directory(TestConfig.outputDir);
-    if (!await outputDir.exists()) {
-      await outputDir.create(recursive: true);
-    }
-
-    // Verify worker exists
-    final workerFile = File(TestConfig.workerPath);
-    if (!await workerFile.exists()) {
-      throw StateError(
-        'Worker not found at ${TestConfig.workerPath}\n'
-        'Run: cd worker && cargo build --release'
-      );
-    }
-
-    // Verify input file exists
-    final inputFile = File(TestConfig.inputFile);
-    if (!await inputFile.exists()) {
-      throw StateError(
-        'Test input file not found at ${TestConfig.inputFile}'
-      );
-    }
-
-    print('Test configuration:');
-    print('  Project root: ${TestConfig.projectRoot}');
-    print('  Input file: ${TestConfig.inputFile}');
-    print('  Output dir: ${TestConfig.outputDir}');
-    print('  Worker: ${TestConfig.workerPath}');
+    await WorkerHarness.ensureReady();
+    await Directory(TestConfig.outputDir).create(recursive: true);
   });
 
   // Store input audio hash for comparison

--- a/app/test/integration_chroma_subsampling_test.dart
+++ b/app/test/integration_chroma_subsampling_test.dart
@@ -2,40 +2,35 @@
 /// These tests verify that ChromaSubsampling settings (original, yuv420, yuv422)
 /// correctly affect the output video's pixel format.
 ///
-/// Run with: flutter test integration_test/chroma_subsampling_test.dart
-/// Or: dart test integration_test/chroma_subsampling_test.dart --chain-stack-traces
+/// Run headless via CI: flutter test test/integration_chroma_subsampling_test.dart
+/// Heavy (full-encode) — tagged so it runs in the nightly workflow, not the push gate.
+@Tags(['heavy'])
+library;
+
+// ignore_for_file: avoid_print — these tests print diagnostics to the test log.
 
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:uuid/uuid.dart';
 
-import '../lib/models/encoding_settings.dart';
-import '../lib/models/qtgmc_parameters.dart';
-import '../lib/models/processing_pipeline.dart';
-import '../lib/models/video_job.dart';
+import 'package:vapourbox/models/encoding_settings.dart';
+import 'package:vapourbox/models/qtgmc_parameters.dart';
+import 'package:vapourbox/models/processing_pipeline.dart';
+import 'package:vapourbox/models/video_job.dart';
 
-/// Test configuration
+import 'support/worker_harness.dart';
+
+/// Thin shim over [WorkerHarness] so the test bodies keep their `TestConfig.*`
+/// call sites while paths/env resolve cross-platform.
 class TestConfig {
-  static final String projectRoot = _findProjectRoot();
-  static String get inputFile => '$projectRoot/Tests/TestResources/interlaced_test.avi';
-  static String get outputDir => '$projectRoot/Tests/TestOutput/chroma';
-  static String get workerPath => '$projectRoot/worker/target/release/vapourbox-worker.exe';
-  static String get depsDir => '$projectRoot/deps/windows-x64';
-
-  static String _findProjectRoot() {
-    var dir = Directory.current;
-    while (!File('${dir.path}/CLAUDE.md').existsSync()) {
-      final parent = dir.parent;
-      if (parent.path == dir.path) {
-        throw StateError('Could not find project root (looking for CLAUDE.md)');
-      }
-      dir = parent;
-    }
-    return dir.path.replaceAll('\\', '/');
-  }
+  static String get projectRoot => WorkerHarness.repoRoot;
+  static String get inputFile => WorkerHarness.inputFile;
+  static String get outputDir => '${WorkerHarness.outputDir}/chroma';
+  static String get workerPath => WorkerHarness.workerPath;
+  static String get depsDir => WorkerHarness.depsDir;
 }
 
 // =============================================================================
@@ -84,7 +79,7 @@ class VideoFormatInfo {
 
 /// Get detailed information about video format using ffprobe
 Future<VideoFormatInfo> getVideoFormatInfo(String videoPath) async {
-  final ffprobePath = '${TestConfig.depsDir}/ffmpeg/ffprobe.exe';
+  final ffprobePath = WorkerHarness.ffprobePath;
 
   final result = await Process.run(
     ffprobePath,
@@ -96,7 +91,7 @@ Future<VideoFormatInfo> getVideoFormatInfo(String videoPath) async {
       videoPath,
     ],
     environment: {
-      'PATH': '${TestConfig.depsDir}/ffmpeg;${Platform.environment['PATH']}',
+      'PATH': '${WorkerHarness.depsDir}/ffmpeg${Platform.isWindows ? ';' : ':'}${Platform.environment['PATH']}',
     },
   );
 
@@ -151,14 +146,8 @@ Future<FilterTestResult> runFilterTest(String testName, VideoJob job, {
   final configFile = File('${Directory.systemTemp.path}/job_${job.id}.json');
   await configFile.writeAsString(jsonEncode(job.toJson()));
 
-  // Set up environment
-  final env = Map<String, String>.from(Platform.environment);
-  final depsDir = TestConfig.depsDir;
-
-  env['PYTHONHOME'] = '$depsDir/vapoursynth';
-  env['PYTHONPATH'] = '$depsDir/vapoursynth/Lib/site-packages';
-  env['PATH'] = '$depsDir/vapoursynth;$depsDir/ffmpeg;${env['PATH']}';
-  env['VAPOURSYNTH_PLUGIN_PATH'] = '$depsDir/vapoursynth/vs-plugins';
+  // Cross-platform worker environment sourced from the shared harness.
+  final env = WorkerHarness.workerEnv;
 
   try {
     print('\n${'=' * 60}');
@@ -311,33 +300,8 @@ void main() {
 
   // Ensure output directory exists
   setUpAll(() async {
-    final outputDir = Directory(TestConfig.outputDir);
-    if (!await outputDir.exists()) {
-      await outputDir.create(recursive: true);
-    }
-
-    // Verify worker exists
-    final workerFile = File(TestConfig.workerPath);
-    if (!await workerFile.exists()) {
-      throw StateError(
-        'Worker not found at ${TestConfig.workerPath}\n'
-        'Run: cd worker && cargo build --release'
-      );
-    }
-
-    // Verify input file exists
-    final inputFile = File(TestConfig.inputFile);
-    if (!await inputFile.exists()) {
-      throw StateError(
-        'Test input file not found at ${TestConfig.inputFile}'
-      );
-    }
-
-    print('Test configuration:');
-    print('  Project root: ${TestConfig.projectRoot}');
-    print('  Input file: ${TestConfig.inputFile}');
-    print('  Output dir: ${TestConfig.outputDir}');
-    print('  Worker: ${TestConfig.workerPath}');
+    await WorkerHarness.ensureReady();
+    await Directory(TestConfig.outputDir).create(recursive: true);
   });
 
   group('Chroma Subsampling Tests', () {

--- a/app/test/integration_filter_parameters_test.dart
+++ b/app/test/integration_filter_parameters_test.dart
@@ -1,44 +1,45 @@
 // Integration test: schema-driven parameter validation for non-deinterlace filters.
-// Run with: dart test integration_test/filter_parameters_test.dart --chain-stack-traces
+// Run headless via CI: flutter test test/integration_filter_parameters_test.dart
+// Script-only (no encode) — runs in the per-push CI gate.
+library;
+
+// ignore_for_file: avoid_print — these tests print diagnostics to the test log.
+
 import 'dart:convert';
 import 'dart:io';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:uuid/uuid.dart';
 
-import '../lib/models/chroma_fix_parameters.dart';
-import '../lib/models/color_correction_parameters.dart';
-import '../lib/models/deband_parameters.dart';
-import '../lib/models/deblock_parameters.dart';
-import '../lib/models/dehalo_parameters.dart';
-import '../lib/models/dynamic_parameters.dart';
-import '../lib/models/encoding_settings.dart';
-import '../lib/models/filter_schema.dart';
-import '../lib/models/noise_reduction_parameters.dart';
-import '../lib/models/parameter_converter.dart';
-import '../lib/models/processing_pipeline.dart';
-import '../lib/models/qtgmc_parameters.dart';
-import '../lib/models/sharpen_parameters.dart';
-import '../lib/models/video_job.dart';
+import 'package:vapourbox/models/chroma_fix_parameters.dart';
+import 'package:vapourbox/models/color_correction_parameters.dart';
+import 'package:vapourbox/models/deband_parameters.dart';
+import 'package:vapourbox/models/deblock_parameters.dart';
+import 'package:vapourbox/models/dehalo_parameters.dart';
+import 'package:vapourbox/models/descratch_parameters.dart';
+import 'package:vapourbox/models/dynamic_parameters.dart';
+import 'package:vapourbox/models/encoding_settings.dart';
+import 'package:vapourbox/models/filter_schema.dart';
+import 'package:vapourbox/models/noise_reduction_parameters.dart';
+import 'package:vapourbox/models/parameter_converter.dart';
+import 'package:vapourbox/models/processing_pipeline.dart';
+import 'package:vapourbox/models/qtgmc_parameters.dart';
+import 'package:vapourbox/models/sharpen_parameters.dart';
+import 'package:vapourbox/models/spotless_parameters.dart';
+import 'package:vapourbox/models/video_job.dart';
+
+import 'support/worker_harness.dart';
 
 // =============================================================================
 // TEST CONFIGURATION
 // =============================================================================
+/// Thin shim over [WorkerHarness] so the test bodies keep their `TestConfig.*`
+/// call sites while paths/env resolve cross-platform.
 class TestConfig {
-  static final String projectRoot = _findProjectRoot();
-  static String get inputFile => '$projectRoot/Tests/TestResources/interlaced_test.avi';
-  static String get outputDir => '$projectRoot/Tests/TestOutput/filter_params';
-  static String get workerPath => '$projectRoot/worker/target/release/vapourbox-worker.exe';
-  static String get depsDir => '$projectRoot/deps/windows-x64';
-
-  static String _findProjectRoot() {
-    var dir = Directory.current;
-    while (!File('${dir.path}/CLAUDE.md').existsSync()) {
-      final parent = dir.parent;
-      if (parent.path == dir.path) throw StateError('Could not find project root');
-      dir = parent;
-    }
-    return dir.path.replaceAll('\\', '/');
-  }
+  static String get projectRoot => WorkerHarness.repoRoot;
+  static String get inputFile => WorkerHarness.inputFile;
+  static String get outputDir => '${WorkerHarness.outputDir}/filter_params';
+  static String get workerPath => WorkerHarness.workerPath;
+  static String get depsDir => WorkerHarness.depsDir;
 }
 
 // =============================================================================
@@ -48,12 +49,7 @@ Future<String> generateScriptViaWorker(VideoJob job) async {
   final configFile = File('${Directory.systemTemp.path}/vapourbox_job_${job.id}.json');
   await configFile.writeAsString(jsonEncode(job.toJson()));
 
-  final env = Map<String, String>.from(Platform.environment);
-  final d = TestConfig.depsDir;
-  env['PYTHONHOME'] = '$d/vapoursynth';
-  env['PYTHONPATH'] = '$d/vapoursynth/Lib/site-packages';
-  env['PATH'] = '$d/vapoursynth;$d/ffmpeg;${env['PATH']}';
-  env['VAPOURSYNTH_PLUGIN_PATH'] = '$d/vapoursynth/vs-plugins';
+  final env = WorkerHarness.workerEnv;
 
   final process = await Process.start(TestConfig.workerPath, ['--config', configFile.path],
       environment: env, workingDirectory: File(TestConfig.workerPath).parent.path);
@@ -162,12 +158,16 @@ VideoJob buildJob({
   SharpenParameters? sharpen,
   ChromaFixParameters? chromaFixes,
   ColorCorrectionParameters? colorCorrection,
+  DeScratchParameters? descratch,
+  SpotLessParameters? spotless,
 }) => VideoJob(
   id: const Uuid().v4(),
   inputPath: TestConfig.inputFile,
   outputPath: '${TestConfig.outputDir}/$testName.mkv',
   processingPipeline: ProcessingPipeline(
     deinterlace: const QTGMCParameters(enabled: false),
+    descratch: descratch ?? const DeScratchParameters(),
+    spotless: spotless ?? const SpotLessParameters(),
     noiseReduction: noiseReduction ?? const NoiseReductionParameters(),
     dehalo: dehalo ?? const DehaloParameters(),
     deblock: deblock ?? const DeblockParameters(),
@@ -194,12 +194,7 @@ String _nrKey(String id) => switch (id) {
 // =============================================================================
 void main() {
   setUpAll(() async {
-    for (final e in {'Worker': TestConfig.workerPath, 'Input': TestConfig.inputFile}.entries) {
-      if (!await File(e.value).exists()) throw StateError('${e.key} not found at ${e.value}');
-    }
-    if (!await Directory(TestConfig.depsDir).exists()) {
-      throw StateError('Deps not found at ${TestConfig.depsDir}');
-    }
+    await WorkerHarness.ensureReady();
     await Directory(TestConfig.outputDir).create(recursive: true);
     print('Project root: ${TestConfig.projectRoot}');
   });
@@ -394,6 +389,51 @@ void main() {
       expect(levels['min_out'], '5'); expect(levels['max_out'], '250');
       expect(levels['gamma'], '0.9');
 
+      print('  PASS');
+    }, timeout: const Timeout(Duration(minutes: 2)));
+
+    // --- DESCRATCH (core.descratch.DeScratch) ---
+    test('descratch: DeScratch params', () async {
+      loadSchema('descratch'); // confirm schema parses
+      // Explicit non-default values so each one is distinguishable in the script.
+      final typed = const DeScratchParameters(
+        enabled: true, mindif: 6, asym: 8, maxgap: 4, maxwidth: 5,
+        blurlen: 12, modeY: 1, modeU: 1,
+      );
+      final job = buildJob(testName: 'descratch', descratch: typed);
+      print('  Generating DeScratch script...');
+      final script = await generateScriptViaWorker(job);
+      expect(script, contains('core.descratch.DeScratch('));
+      final actual = parseFilterParams(script, 'core.descratch.DeScratch(');
+      print('  Parsed ${actual.length} params');
+      expect(actual['mindif'], '6');
+      expect(actual['asym'], '8');
+      expect(actual['maxgap'], '4');
+      expect(actual['maxwidth'], '5');
+      expect(actual['blurlen'], '12');
+      expect(actual['modey'], '1');
+      expect(actual['modeu'], '1');
+      print('  PASS');
+    }, timeout: const Timeout(Duration(minutes: 2)));
+
+    // --- SPOTLESS (_SpotLess) ---
+    test('spotless: SpotLess params', () async {
+      loadSchema('spotless'); // confirm schema parses
+      // chroma/blksize/overlap/pel set to non-defaults; rec toggled on.
+      final typed = const SpotLessParameters(
+        enabled: true, chroma: false, rec: true, blksize: 8, overlap: 4, pel: 1,
+      );
+      final job = buildJob(testName: 'spotless', spotless: typed);
+      print('  Generating SpotLess script...');
+      final script = await generateScriptViaWorker(job);
+      expect(script, contains('_SpotLess('));
+      final actual = parseFilterParams(script, '_SpotLess(');
+      print('  Parsed ${actual.length} params');
+      expect(actual['chroma'], 'False');
+      expect(actual['rec'], 'True');
+      expect(actual['blksize'], '8');
+      expect(actual['overlap'], '4');
+      expect(actual['pel'], '1');
       print('  PASS');
     }, timeout: const Timeout(Duration(minutes: 2)));
   });

--- a/app/test/integration_filter_pipeline_test.dart
+++ b/app/test/integration_filter_pipeline_test.dart
@@ -2,8 +2,12 @@
 /// These tests spawn the actual worker process and run video processing.
 /// Each filter test verifies the output differs from a baseline (no filters).
 ///
-/// Run with: flutter test integration_test/filter_pipeline_test.dart
-/// Or: dart test integration_test/filter_pipeline_test.dart --chain-stack-traces
+/// Run headless via CI: flutter test test/integration_filter_pipeline_test.dart
+/// Heavy (full-encode) — tagged so it runs in the nightly workflow, not the push gate.
+@Tags(['heavy'])
+library;
+
+// ignore_for_file: avoid_print — these tests print diagnostics to the test log.
 
 import 'dart:async';
 import 'dart:convert';
@@ -11,42 +15,34 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'package:crypto/crypto.dart';
 
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:uuid/uuid.dart';
 
-import '../lib/models/chroma_fix_parameters.dart';
-import '../lib/models/color_correction_parameters.dart';
-import '../lib/models/crop_resize_parameters.dart';
-import '../lib/models/deband_parameters.dart';
-import '../lib/models/deblock_parameters.dart';
-import '../lib/models/dehalo_parameters.dart';
-import '../lib/models/encoding_settings.dart';
-import '../lib/models/noise_reduction_parameters.dart';
-import '../lib/models/qtgmc_parameters.dart';
-import '../lib/models/processing_pipeline.dart';
-import '../lib/models/sharpen_parameters.dart';
-import '../lib/models/video_job.dart';
+import 'package:vapourbox/models/chroma_fix_parameters.dart';
+import 'package:vapourbox/models/color_correction_parameters.dart';
+import 'package:vapourbox/models/crop_resize_parameters.dart';
+import 'package:vapourbox/models/deband_parameters.dart';
+import 'package:vapourbox/models/deblock_parameters.dart';
+import 'package:vapourbox/models/dehalo_parameters.dart';
+import 'package:vapourbox/models/encoding_settings.dart';
+import 'package:vapourbox/models/noise_reduction_parameters.dart';
+import 'package:vapourbox/models/qtgmc_parameters.dart';
+import 'package:vapourbox/models/processing_pipeline.dart';
+import 'package:vapourbox/models/sharpen_parameters.dart';
+import 'package:vapourbox/models/video_job.dart';
 
-/// Test configuration
+import 'support/worker_harness.dart';
+
+/// Thin shim over [WorkerHarness] so the test bodies below keep their original
+/// `TestConfig.*` call sites while paths/env resolve cross-platform.
 class TestConfig {
-  static final String projectRoot = _findProjectRoot();
-  static String get inputFile => '$projectRoot/Tests/TestResources/interlaced_test.avi';
-  static String get outputDir => '$projectRoot/Tests/TestOutput';
-  static String get workerPath => '$projectRoot/worker/target/release/vapourbox-worker.exe';
-  static String get depsDir => '$projectRoot/deps/windows-x64';
-  static String get baselineFile => '$outputDir/baseline_deinterlace_only.avi';
-
-  static String _findProjectRoot() {
-    var dir = Directory.current;
-    while (!File('${dir.path}/CLAUDE.md').existsSync()) {
-      final parent = dir.parent;
-      if (parent.path == dir.path) {
-        throw StateError('Could not find project root (looking for CLAUDE.md)');
-      }
-      dir = parent;
-    }
-    return dir.path.replaceAll('\\', '/');
-  }
+  static String get projectRoot => WorkerHarness.repoRoot;
+  static String get inputFile => WorkerHarness.inputFile;
+  static String get outputDir => WorkerHarness.outputDir;
+  static String get workerPath => WorkerHarness.workerPath;
+  static String get depsDir => WorkerHarness.depsDir;
+  static String get baselineFile =>
+      '${WorkerHarness.outputDir}/baseline_deinterlace_only.avi';
 }
 
 /// Global baseline frame hash for comparison (visual content only)
@@ -81,7 +77,7 @@ class AudioStreamInfo {
 
 /// Get information about audio streams in a video file using ffprobe
 Future<AudioStreamInfo> getAudioStreamInfo(String videoPath) async {
-  final ffprobePath = '${TestConfig.depsDir}/ffmpeg/ffprobe.exe';
+  final ffprobePath = WorkerHarness.ffprobePath;
 
   final result = await Process.run(
     ffprobePath,
@@ -92,9 +88,7 @@ Future<AudioStreamInfo> getAudioStreamInfo(String videoPath) async {
       '-of', 'json',
       videoPath,
     ],
-    environment: {
-      'PATH': '${TestConfig.depsDir}/ffmpeg;${Platform.environment['PATH']}',
-    },
+    environment: WorkerHarness.ffmpegEnv,
   );
 
   if (result.exitCode != 0) {
@@ -121,17 +115,21 @@ Future<AudioStreamInfo> getAudioStreamInfo(String videoPath) async {
 /// Extract raw audio from a video file as PCM WAV for binary comparison
 /// Returns the MD5 hash of the audio data, or null if no audio
 Future<String?> extractAudioHash(String videoPath) async {
-  final ffmpegPath = '${TestConfig.depsDir}/ffmpeg/ffmpeg.exe';
+  final ffmpegPath = WorkerHarness.ffmpegPath;
   final tempDir = Directory.systemTemp;
-  final audioPath = '${tempDir.path}/audio_${DateTime.now().millisecondsSinceEpoch}.wav';
+  final audioPath = '${tempDir.path}/audio_${DateTime.now().millisecondsSinceEpoch}.raw';
 
   try {
-    // Extract audio as raw PCM WAV (lossless extraction for comparison)
+    // Extract audio as headerless raw PCM (s16le) — NOT a WAV. A WAV header
+    // varies by source container metadata (RIFF size / INFO chunk) even when the
+    // samples are identical, which makes a passthrough copy hash differently from
+    // its source. Raw PCM hashes the audio content only.
     await Process.run(
       ffmpegPath,
       [
         '-i', videoPath,
         '-vn',                    // No video
+        '-f', 's16le',            // Headerless raw PCM container
         '-acodec', 'pcm_s16le',   // Convert to PCM for consistent comparison
         '-ar', '48000',           // Resample to 48kHz for consistency
         '-ac', '2',               // Stereo
@@ -139,7 +137,7 @@ Future<String?> extractAudioHash(String videoPath) async {
         audioPath,
       ],
       environment: {
-        'PATH': '${TestConfig.depsDir}/ffmpeg;${Platform.environment['PATH']}',
+        'PATH': '${WorkerHarness.depsDir}/ffmpeg${Platform.isWindows ? ';' : ':'}${Platform.environment['PATH']}',
       },
     );
 
@@ -172,7 +170,7 @@ Future<String?> extractAudioHash(String videoPath) async {
 /// Extract raw audio bytes from a video for detailed comparison
 /// Returns raw audio data as Uint8List, or null if no audio
 Future<Uint8List?> extractAudioBytes(String videoPath) async {
-  final ffmpegPath = '${TestConfig.depsDir}/ffmpeg/ffmpeg.exe';
+  final ffmpegPath = WorkerHarness.ffmpegPath;
   final tempDir = Directory.systemTemp;
   final audioPath = '${tempDir.path}/audio_${DateTime.now().millisecondsSinceEpoch}.raw';
 
@@ -191,7 +189,7 @@ Future<Uint8List?> extractAudioBytes(String videoPath) async {
         audioPath,
       ],
       environment: {
-        'PATH': '${TestConfig.depsDir}/ffmpeg;${Platform.environment['PATH']}',
+        'PATH': '${WorkerHarness.depsDir}/ffmpeg${Platform.isWindows ? ';' : ':'}${Platform.environment['PATH']}',
       },
     );
 
@@ -218,7 +216,7 @@ Future<Uint8List?> extractAudioBytes(String videoPath) async {
 Future<String> extractFrameHash(String videoPath, {int frameNumber = 5}) async {
   final tempDir = Directory.systemTemp;
   final framePath = '${tempDir.path}/frame_${DateTime.now().millisecondsSinceEpoch}.png';
-  final ffmpegPath = '${TestConfig.depsDir}/ffmpeg/ffmpeg.exe';
+  final ffmpegPath = WorkerHarness.ffmpegPath;
 
   try {
     // Extract a specific frame as PNG (lossless, no metadata variation)
@@ -232,7 +230,7 @@ Future<String> extractFrameHash(String videoPath, {int frameNumber = 5}) async {
         framePath,
       ],
       environment: {
-        'PATH': '${TestConfig.depsDir}/ffmpeg;${Platform.environment['PATH']}',
+        'PATH': '${WorkerHarness.depsDir}/ffmpeg${Platform.isWindows ? ';' : ':'}${Platform.environment['PATH']}',
       },
     );
 
@@ -324,14 +322,8 @@ Future<PreviewTestResult> runPreviewTest(
   final configFile = File('${Directory.systemTemp.path}/preview_${job.id}.json');
   await configFile.writeAsString(jsonEncode(job.toJson()));
 
-  // Set up environment
-  final env = Map<String, String>.from(Platform.environment);
-  final depsDir = TestConfig.depsDir;
-
-  env['PYTHONHOME'] = '$depsDir/vapoursynth';
-  env['PYTHONPATH'] = '$depsDir/vapoursynth/Lib/site-packages';
-  env['PATH'] = '$depsDir/vapoursynth;$depsDir/ffmpeg;${env['PATH']}';
-  env['VAPOURSYNTH_PLUGIN_PATH'] = '$depsDir/vapoursynth/vs-plugins';
+  // Cross-platform worker environment sourced from the shared harness.
+  final env = WorkerHarness.workerEnv;
 
   try {
     print('\n${'=' * 60}');
@@ -470,14 +462,8 @@ Future<FilterTestResult> runFilterTest(
   final configFile = File('${Directory.systemTemp.path}/test_${job.id}.json');
   await configFile.writeAsString(jsonEncode(job.toJson()));
 
-  // Set up environment
-  final env = Map<String, String>.from(Platform.environment);
-  final depsDir = TestConfig.depsDir;
-
-  env['PYTHONHOME'] = '$depsDir/vapoursynth';
-  env['PYTHONPATH'] = '$depsDir/vapoursynth/Lib/site-packages';
-  env['PATH'] = '$depsDir/vapoursynth;$depsDir/ffmpeg;${env['PATH']}';
-  env['VAPOURSYNTH_PLUGIN_PATH'] = '$depsDir/vapoursynth/vs-plugins';
+  // Cross-platform worker environment sourced from the shared harness.
+  final env = WorkerHarness.workerEnv;
 
   try {
     print('\n${'=' * 60}');
@@ -621,31 +607,10 @@ VideoJob createTestJob(String outputName, {String extension = 'avi'}) {
 void main() {
   // Ensure output directory exists
   setUpAll(() async {
-    final outputDir = Directory(TestConfig.outputDir);
-    if (!await outputDir.exists()) {
-      await outputDir.create(recursive: true);
-    }
-
-    // Verify prerequisites
-    final workerFile = File(TestConfig.workerPath);
-    if (!await workerFile.exists()) {
-      fail('Worker not found at ${TestConfig.workerPath}. Run: cd worker && cargo build --release');
-    }
-
-    final inputFile = File(TestConfig.inputFile);
-    if (!await inputFile.exists()) {
-      fail('Test input not found at ${TestConfig.inputFile}');
-    }
-
-    final depsDir = Directory(TestConfig.depsDir);
-    if (!await depsDir.exists()) {
-      fail('Dependencies not found at ${TestConfig.depsDir}. Run download-deps-windows.ps1');
-    }
-
-    print('Project root: ${TestConfig.projectRoot}');
-    print('Input file: ${TestConfig.inputFile}');
-    print('Output dir: ${TestConfig.outputDir}');
-    print('Worker: ${TestConfig.workerPath}');
+    // Resolves deps (downloading the pinned release if absent), locates the
+    // worker + input fixture, and creates the output dir. Throws with an
+    // actionable message if anything required can't be obtained.
+    await WorkerHarness.ensureReady();
   });
 
   // BASELINE TEST - Must run first to establish comparison reference
@@ -985,9 +950,7 @@ void main() {
             enabled: true,
             applyVinverse: true,
             vinverseSstr: 2.0,
-            vinverseAmnt: 200,
-            vinverseScl: 12,
-          ),
+            vinverseAmnt: 200,          ),
         ),
         encodingSettings: job.encodingSettings,
       );
@@ -1445,9 +1408,7 @@ void main() {
             chromaBleedStrength: 0.8,
             applyVinverse: true,
             vinverseSstr: 2.0,
-            vinverseAmnt: 200,
-            vinverseScl: 12,
-          ),
+            vinverseAmnt: 200,          ),
           cropResize: CropResizeParameters(
             enabled: true,
             resizeEnabled: true,
@@ -1830,9 +1791,7 @@ void main() {
             enabled: true,
             applyVinverse: true,
             vinverseSstr: 2.0,
-            vinverseAmnt: 200,
-            vinverseScl: 12,
-          ),
+            vinverseAmnt: 200,          ),
         ),
         encodingSettings: const EncodingSettings(
           codec: VideoCodec.ffv1,
@@ -2339,7 +2298,7 @@ void main() {
 
   group('Audio Passthrough', () {
     // Store input audio hash for comparison
-    String? _inputAudioHash;
+    String? inputAudioHash;
 
     test('Setup: Verify input file has audio', () async {
       print('\n${'=' * 60}');
@@ -2359,11 +2318,11 @@ void main() {
       );
 
       // Store input audio hash for later comparison
-      _inputAudioHash = await extractAudioHash(TestConfig.inputFile);
-      print('Input audio hash: $_inputAudioHash');
+      inputAudioHash = await extractAudioHash(TestConfig.inputFile);
+      print('Input audio hash: $inputAudioHash');
 
       expect(
-        _inputAudioHash,
+        inputAudioHash,
         isNotNull,
         reason: 'Failed to extract audio hash from input file',
       );
@@ -2393,7 +2352,7 @@ void main() {
         encodingSettings: const EncodingSettings(
           codec: VideoCodec.ffv1,
           container: ContainerFormat.avi,
-          audioCopy: true, // Explicitly set (this is also the default)
+          audioMode: AudioMode.passthrough, // Explicitly set (also the default)
         ),
       );
 
@@ -2413,7 +2372,7 @@ void main() {
       // Extract and compare audio
       final outputAudioHash = await extractAudioHash(result.outputPath!);
       print('  Output audio hash: $outputAudioHash');
-      print('  Input audio hash:  $_inputAudioHash');
+      print('  Input audio hash:  $inputAudioHash');
 
       expect(
         outputAudioHash,
@@ -2425,9 +2384,9 @@ void main() {
       // Note: Due to container differences, we compare normalized PCM audio
       expect(
         outputAudioHash,
-        equals(_inputAudioHash),
+        equals(inputAudioHash),
         reason: 'Audio with audioCopy=true should match input exactly!\n'
-            'Input hash:  $_inputAudioHash\n'
+            'Input hash:  $inputAudioHash\n'
             'Output hash: $outputAudioHash\n'
             'This means audio was modified when it should have been copied unchanged.',
       );
@@ -2459,9 +2418,9 @@ void main() {
         encodingSettings: const EncodingSettings(
           codec: VideoCodec.h264,
           container: ContainerFormat.mp4,
-          audioCopy: false,      // Re-encode audio
-          audioCodec: 'aac',
-          audioBitrate: 128,     // Lower bitrate to make difference obvious
+          audioMode: AudioMode.convert, // Re-encode audio
+          audioCodec: AudioCodec.aac,
+          audioQuality: AudioQuality.medium, // 128 kbps — lower to make the difference obvious
         ),
       );
 
@@ -2488,7 +2447,7 @@ void main() {
       // Extract and compare audio - should be DIFFERENT from input
       final outputAudioHash = await extractAudioHash(result.outputPath!);
       print('  Output audio hash: $outputAudioHash');
-      print('  Input audio hash:  $_inputAudioHash');
+      print('  Input audio hash:  $inputAudioHash');
 
       expect(
         outputAudioHash,
@@ -2500,9 +2459,9 @@ void main() {
       // (unless original was already AAC 128kbps, which is unlikely)
       expect(
         outputAudioHash,
-        isNot(equals(_inputAudioHash)),
+        isNot(equals(inputAudioHash)),
         reason: 'Re-encoded audio should differ from input!\n'
-            'Input hash:  $_inputAudioHash\n'
+            'Input hash:  $inputAudioHash\n'
             'Output hash: $outputAudioHash\n'
             'Audio appears unchanged despite audioCopy=false.',
       );
@@ -2605,7 +2564,7 @@ void main() {
         encodingSettings: const EncodingSettings(
           codec: VideoCodec.ffv1,
           container: ContainerFormat.avi,
-          audioCopy: true, // Keep audio unchanged despite video filters
+          audioMode: AudioMode.passthrough, // Keep audio unchanged despite video filters
         ),
       );
 
@@ -2625,13 +2584,13 @@ void main() {
       // Extract and compare audio - should match input exactly
       final outputAudioHash = await extractAudioHash(result.outputPath!);
       print('  Output audio hash: $outputAudioHash');
-      print('  Input audio hash:  $_inputAudioHash');
+      print('  Input audio hash:  $inputAudioHash');
 
       expect(
         outputAudioHash,
-        equals(_inputAudioHash),
+        equals(inputAudioHash),
         reason: 'Audio should match input even with heavy video processing!\n'
-            'Input hash:  $_inputAudioHash\n'
+            'Input hash:  $inputAudioHash\n'
             'Output hash: $outputAudioHash\n'
             'Video filters should not affect audio when audioCopy=true.',
       );
@@ -2664,7 +2623,7 @@ void main() {
         encodingSettings: const EncodingSettings(
           codec: VideoCodec.h264,
           container: ContainerFormat.mkv,
-          audioCopy: true,
+          audioMode: AudioMode.passthrough,
         ),
       );
 
@@ -2688,7 +2647,7 @@ void main() {
       // MKV should match input (codec is compatible, so it's copied)
       expect(
         mkvAudioHash,
-        equals(_inputAudioHash),
+        equals(inputAudioHash),
         reason: 'MKV audio should match input (PCM is compatible)',
       );
 
@@ -2719,9 +2678,9 @@ void main() {
         encodingSettings: const EncodingSettings(
           codec: VideoCodec.h264,
           container: ContainerFormat.mp4,
-          audioCopy: false, // User chose to re-encode
-          audioCodec: 'aac',
-          audioBitrate: 128,
+          audioMode: AudioMode.convert, // User chose to re-encode
+          audioCodec: AudioCodec.aac,
+          audioQuality: AudioQuality.medium, // 128 kbps
         ),
       );
 
@@ -2735,12 +2694,12 @@ void main() {
 
       final outputHash = await extractAudioHash(result.outputPath!);
       print('  Output audio hash: $outputHash');
-      print('  Input audio hash:  $_inputAudioHash');
+      print('  Input audio hash:  $inputAudioHash');
 
       // Re-encoded audio will differ from input
       expect(
         outputHash,
-        isNot(equals(_inputAudioHash)),
+        isNot(equals(inputAudioHash)),
         reason: 'Re-encoded audio should differ from input',
       );
 
@@ -2771,7 +2730,7 @@ void main() {
         encodingSettings: const EncodingSettings(
           codec: VideoCodec.h264,
           container: ContainerFormat.mkv, // User changed to compatible container
-          audioCopy: true, // Can now copy because MKV supports PCM
+          audioMode: AudioMode.passthrough, // Can now copy because MKV supports PCM
         ),
       );
 
@@ -2785,12 +2744,12 @@ void main() {
 
       final outputHash = await extractAudioHash(result.outputPath!);
       print('  Output audio hash: $outputHash');
-      print('  Input audio hash:  $_inputAudioHash');
+      print('  Input audio hash:  $inputAudioHash');
 
       // Copied audio should match input exactly
       expect(
         outputHash,
-        equals(_inputAudioHash),
+        equals(inputAudioHash),
         reason: 'Copied audio should match input exactly',
       );
 

--- a/app/test/integration_interlacing_status_test.dart
+++ b/app/test/integration_interlacing_status_test.dart
@@ -3,40 +3,35 @@
 /// - Deinterlaced videos are marked as progressive
 /// - Videos not deinterlaced (passthrough) retain their interlaced status
 ///
-/// Run with: flutter test integration_test/interlacing_status_test.dart
-/// Or: dart test integration_test/interlacing_status_test.dart --chain-stack-traces
+/// Run headless via CI: flutter test test/integration_interlacing_status_test.dart
+/// Heavy (full-encode) — tagged so it runs in the nightly workflow, not the push gate.
+@Tags(['heavy'])
+library;
+
+// ignore_for_file: avoid_print — these tests print diagnostics to the test log.
 
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:uuid/uuid.dart';
 
-import '../lib/models/encoding_settings.dart';
-import '../lib/models/qtgmc_parameters.dart';
-import '../lib/models/processing_pipeline.dart';
-import '../lib/models/video_job.dart';
+import 'package:vapourbox/models/encoding_settings.dart';
+import 'package:vapourbox/models/qtgmc_parameters.dart';
+import 'package:vapourbox/models/processing_pipeline.dart';
+import 'package:vapourbox/models/video_job.dart';
 
-/// Test configuration
+import 'support/worker_harness.dart';
+
+/// Thin shim over [WorkerHarness] so the test bodies keep their `TestConfig.*`
+/// call sites while paths/env resolve cross-platform.
 class TestConfig {
-  static final String projectRoot = _findProjectRoot();
-  static String get inputFile => '$projectRoot/Tests/TestResources/interlaced_test.avi';
-  static String get outputDir => '$projectRoot/Tests/TestOutput/interlacing';
-  static String get workerPath => '$projectRoot/worker/target/release/vapourbox-worker.exe';
-  static String get depsDir => '$projectRoot/deps/windows-x64';
-
-  static String _findProjectRoot() {
-    var dir = Directory.current;
-    while (!File('${dir.path}/CLAUDE.md').existsSync()) {
-      final parent = dir.parent;
-      if (parent.path == dir.path) {
-        throw StateError('Could not find project root (looking for CLAUDE.md)');
-      }
-      dir = parent;
-    }
-    return dir.path.replaceAll('\\', '/');
-  }
+  static String get projectRoot => WorkerHarness.repoRoot;
+  static String get inputFile => WorkerHarness.inputFile;
+  static String get outputDir => '${WorkerHarness.outputDir}/interlacing';
+  static String get workerPath => WorkerHarness.workerPath;
+  static String get depsDir => WorkerHarness.depsDir;
 }
 
 // =============================================================================
@@ -106,7 +101,7 @@ class VideoInterlacingInfo {
 
 /// Get interlacing information using ffprobe
 Future<VideoInterlacingInfo> getVideoInterlacingInfo(String videoPath) async {
-  final ffprobePath = '${TestConfig.depsDir}/ffmpeg/ffprobe.exe';
+  final ffprobePath = WorkerHarness.ffprobePath;
 
   final result = await Process.run(
     ffprobePath,
@@ -118,7 +113,7 @@ Future<VideoInterlacingInfo> getVideoInterlacingInfo(String videoPath) async {
       videoPath,
     ],
     environment: {
-      'PATH': '${TestConfig.depsDir}/ffmpeg;${Platform.environment['PATH']}',
+      'PATH': '${WorkerHarness.depsDir}/ffmpeg${Platform.isWindows ? ';' : ':'}${Platform.environment['PATH']}',
     },
   );
 
@@ -144,7 +139,7 @@ Future<VideoInterlacingInfo> getVideoInterlacingInfo(String videoPath) async {
 
 /// Use ffprobe to detect interlacing through frame analysis
 Future<bool> detectInterlacingViaFrameAnalysis(String videoPath) async {
-  final ffprobePath = '${TestConfig.depsDir}/ffmpeg/ffprobe.exe';
+  final ffprobePath = WorkerHarness.ffprobePath;
 
   // Use idet filter via ffprobe to detect interlacing
   final result = await Process.run(
@@ -159,7 +154,7 @@ Future<bool> detectInterlacingViaFrameAnalysis(String videoPath) async {
       videoPath,
     ],
     environment: {
-      'PATH': '${TestConfig.depsDir}/ffmpeg;${Platform.environment['PATH']}',
+      'PATH': '${WorkerHarness.depsDir}/ffmpeg${Platform.isWindows ? ';' : ':'}${Platform.environment['PATH']}',
     },
   );
 
@@ -218,14 +213,8 @@ Future<FilterTestResult> runFilterTest(String testName, VideoJob job, {
   final configFile = File('${Directory.systemTemp.path}/job_${job.id}.json');
   await configFile.writeAsString(jsonEncode(job.toJson()));
 
-  // Set up environment
-  final env = Map<String, String>.from(Platform.environment);
-  final depsDir = TestConfig.depsDir;
-
-  env['PYTHONHOME'] = '$depsDir/vapoursynth';
-  env['PYTHONPATH'] = '$depsDir/vapoursynth/Lib/site-packages';
-  env['PATH'] = '$depsDir/vapoursynth;$depsDir/ffmpeg;${env['PATH']}';
-  env['VAPOURSYNTH_PLUGIN_PATH'] = '$depsDir/vapoursynth/vs-plugins';
+  // Cross-platform worker environment sourced from the shared harness.
+  final env = WorkerHarness.workerEnv;
 
   try {
     print('\n${'=' * 60}');
@@ -407,33 +396,8 @@ void main() {
 
   // Ensure output directory exists
   setUpAll(() async {
-    final outputDir = Directory(TestConfig.outputDir);
-    if (!await outputDir.exists()) {
-      await outputDir.create(recursive: true);
-    }
-
-    // Verify worker exists
-    final workerFile = File(TestConfig.workerPath);
-    if (!await workerFile.exists()) {
-      throw StateError(
-        'Worker not found at ${TestConfig.workerPath}\n'
-        'Run: cd worker && cargo build --release'
-      );
-    }
-
-    // Verify input file exists
-    final inputFile = File(TestConfig.inputFile);
-    if (!await inputFile.exists()) {
-      throw StateError(
-        'Test input file not found at ${TestConfig.inputFile}'
-      );
-    }
-
-    print('Test configuration:');
-    print('  Project root: ${TestConfig.projectRoot}');
-    print('  Input file: ${TestConfig.inputFile}');
-    print('  Output dir: ${TestConfig.outputDir}');
-    print('  Worker: ${TestConfig.workerPath}');
+    await WorkerHarness.ensureReady();
+    await Directory(TestConfig.outputDir).create(recursive: true);
   });
 
   group('Interlacing Status Tests', () {

--- a/app/test/integration_new_passes_test.dart
+++ b/app/test/integration_new_passes_test.dart
@@ -1,0 +1,117 @@
+/// Full-encode smoke tests for the pipeline passes that previously had no
+/// integration coverage: descratch, spotless, and subtitles.
+///
+/// These run the worker end-to-end (vspipe | ffmpeg) and confirm the pass loads
+/// its plugin / add-on and produces a valid output video — complementing the
+/// cheaper script-generation assertions in integration_filter_parameters_test.
+///
+/// Run headless via CI: flutter test test/integration_new_passes_test.dart
+/// Heavy (full-encode) — tagged so it runs in the nightly workflow, not the push gate.
+@Tags(['heavy'])
+library;
+
+// ignore_for_file: avoid_print — these tests print diagnostics to the test log.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:uuid/uuid.dart';
+
+import 'package:vapourbox/models/descratch_parameters.dart';
+import 'package:vapourbox/models/encoding_settings.dart';
+import 'package:vapourbox/models/processing_pipeline.dart';
+import 'package:vapourbox/models/qtgmc_parameters.dart';
+import 'package:vapourbox/models/spotless_parameters.dart';
+import 'package:vapourbox/models/subtitle_parameters.dart';
+import 'package:vapourbox/models/video_job.dart';
+
+import 'support/worker_harness.dart';
+
+String get _outDir => '${WorkerHarness.outputDir}/new_passes';
+
+VideoJob _baseJob(
+  String name, {
+  ProcessingPipeline? pipeline,
+  SubtitleSettingsDto? subtitleSettings,
+}) =>
+    VideoJob(
+      id: const Uuid().v4(),
+      inputPath: WorkerHarness.inputFile,
+      outputPath: '$_outDir/$name.mkv',
+      processingPipeline: pipeline ??
+          const ProcessingPipeline(
+            deinterlace: QTGMCParameters(preset: QTGMCPreset.fast, tff: true, fpsDivisor: 2),
+          ),
+      encodingSettings: const EncodingSettings(
+        codec: VideoCodec.h264,
+        container: ContainerFormat.mkv,
+        audioMode: AudioMode.passthrough,
+      ),
+      subtitleSettings: subtitleSettings,
+    );
+
+/// Assert the worker produced a playable video with a video stream.
+Future<void> _expectValidVideo(JobResult result) async {
+  expect(result.success, isTrue, reason: result.error);
+  expect(File(result.outputPath!).existsSync(), isTrue,
+      reason: 'output file should exist');
+  final v = await WorkerHarness.firstStream(result.outputPath!,
+      selector: 'v:0', entries: ['codec_name', 'width', 'height']);
+  expect(v, isNotNull, reason: 'output should contain a video stream');
+  print('  output video: ${v?['codec_name']} ${v?['width']}x${v?['height']}');
+}
+
+void main() {
+  setUpAll(() async {
+    await WorkerHarness.ensureReady();
+    await Directory(_outDir).create(recursive: true);
+  });
+
+  group('New pipeline passes (full encode)', () {
+    test('descratch: DeScratch runs end-to-end', () async {
+      final job = _baseJob(
+        'descratch',
+        pipeline: const ProcessingPipeline(
+          deinterlace: QTGMCParameters(preset: QTGMCPreset.fast, tff: true, fpsDivisor: 2),
+          descratch: DeScratchParameters(enabled: true, mindif: 6, maxgap: 4),
+        ),
+      );
+      final result = await WorkerHarness.runJob(job.toJson(), label: 'descratch');
+      await _expectValidVideo(result);
+    }, timeout: const Timeout(Duration(minutes: 5)));
+
+    test('spotless: SpotLess runs end-to-end', () async {
+      final job = _baseJob(
+        'spotless',
+        pipeline: const ProcessingPipeline(
+          deinterlace: QTGMCParameters(preset: QTGMCPreset.fast, tff: true, fpsDivisor: 2),
+          spotless: SpotLessParameters(enabled: true, blksize: 8, overlap: 4, pel: 1),
+        ),
+      );
+      final result = await WorkerHarness.runJob(job.toJson(), label: 'spotless');
+      await _expectValidVideo(result);
+    }, timeout: const Timeout(Duration(minutes: 5)));
+
+    // Subtitles run a separate whisper pass after encode. We assert the pass
+    // integrates without breaking the pipeline (valid output video). SRT content
+    // depends on speech in the input audio, so we don't assert on it here.
+    test('subtitles: whisper pass runs end-to-end', () async {
+      final job = _baseJob(
+        'subtitles',
+        subtitleSettings: SubtitleSettingsDto.fromSubtitleParameters(
+          const SubtitleParameters(
+            enabled: true,
+            model: WhisperModel.small,
+            output: SubtitleOutput.srtFile,
+          ),
+        ),
+      );
+      final result = await WorkerHarness.runJob(job.toJson(), label: 'subtitles');
+      await _expectValidVideo(result);
+    },
+        timeout: const Timeout(Duration(minutes: 8)),
+        skip: WorkerHarness.whisperAvailable
+            ? false
+            : 'whisper add-on not present (set VAPOURBOX_ADDONS_DIR or install the add-on)');
+  });
+}

--- a/app/test/integration_qtgmc_parameters_test.dart
+++ b/app/test/integration_qtgmc_parameters_test.dart
@@ -7,49 +7,41 @@
 /// 4. Validate that every enabled parameter appears in the generated .vpy script
 ///    with the correct value matching what was set via the schema
 ///
-/// Run with: dart test integration_test/qtgmc_parameters_test.dart --chain-stack-traces
+/// Run headless via CI: flutter test test/integration_qtgmc_parameters_test.dart
+/// Script-only (no encode) — runs in the per-push CI gate.
+library;
+
+// ignore_for_file: avoid_print — these tests print diagnostics to the test log.
 
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:uuid/uuid.dart';
 
-import '../lib/models/dynamic_parameters.dart';
-import '../lib/models/encoding_settings.dart';
-import '../lib/models/filter_schema.dart';
-import '../lib/models/parameter_converter.dart';
-import '../lib/models/processing_pipeline.dart';
-import '../lib/models/qtgmc_parameters.dart';
-import '../lib/models/video_job.dart';
+import 'package:vapourbox/models/dynamic_parameters.dart';
+import 'package:vapourbox/models/encoding_settings.dart';
+import 'package:vapourbox/models/filter_schema.dart';
+import 'package:vapourbox/models/parameter_converter.dart';
+import 'package:vapourbox/models/processing_pipeline.dart';
+import 'package:vapourbox/models/qtgmc_parameters.dart';
+import 'package:vapourbox/models/video_job.dart';
+
+import 'support/worker_harness.dart';
 
 // =============================================================================
 // TEST CONFIGURATION
 // =============================================================================
 
+/// Thin shim over [WorkerHarness] so the test bodies keep their `TestConfig.*`
+/// call sites while paths/env resolve cross-platform.
 class TestConfig {
-  static final String projectRoot = _findProjectRoot();
-  static String get inputFile =>
-      '$projectRoot/Tests/TestResources/interlaced_test.avi';
-  static String get outputDir =>
-      '$projectRoot/Tests/TestOutput/qtgmc_params';
-  static String get workerPath =>
-      '$projectRoot/worker/target/release/vapourbox-worker.exe';
-  static String get depsDir => '$projectRoot/deps/windows-x64';
-  static String get ffmpegPath => '$depsDir/ffmpeg/ffmpeg.exe';
-
-  static String _findProjectRoot() {
-    var dir = Directory.current;
-    while (!File('${dir.path}/CLAUDE.md').existsSync()) {
-      final parent = dir.parent;
-      if (parent.path == dir.path) {
-        throw StateError(
-            'Could not find project root (looking for CLAUDE.md)');
-      }
-      dir = parent;
-    }
-    return dir.path.replaceAll('\\', '/');
-  }
+  static String get projectRoot => WorkerHarness.repoRoot;
+  static String get inputFile => WorkerHarness.inputFile;
+  static String get outputDir => '${WorkerHarness.outputDir}/qtgmc_params';
+  static String get workerPath => WorkerHarness.workerPath;
+  static String get depsDir => WorkerHarness.depsDir;
+  static String get ffmpegPath => WorkerHarness.ffmpegPath;
 }
 
 // =============================================================================
@@ -65,7 +57,7 @@ Future<DetectedScanType> detectScanType(String videoPath) async {
     ['-i', videoPath, '-vf', 'idet=half_life=0', '-frames:v', '200',
      '-an', '-f', 'null', '-'],
     environment: {
-      'PATH': '${TestConfig.depsDir}/ffmpeg;${Platform.environment['PATH']}',
+      'PATH': '${WorkerHarness.depsDir}/ffmpeg${Platform.isWindows ? ';' : ':'}${Platform.environment['PATH']}',
     },
   );
 
@@ -103,12 +95,7 @@ Future<String> generateScriptViaWorker(VideoJob job) async {
       File('${Directory.systemTemp.path}/vapourbox_job_${job.id}.json');
   await configFile.writeAsString(jsonEncode(job.toJson()));
 
-  final env = Map<String, String>.from(Platform.environment);
-  final d = TestConfig.depsDir;
-  env['PYTHONHOME'] = '$d/vapoursynth';
-  env['PYTHONPATH'] = '$d/vapoursynth/Lib/site-packages';
-  env['PATH'] = '$d/vapoursynth;$d/ffmpeg;${env['PATH']}';
-  env['VAPOURSYNTH_PLUGIN_PATH'] = '$d/vapoursynth/vs-plugins';
+  final env = WorkerHarness.workerEnv;
 
   final process = await Process.start(
     TestConfig.workerPath,
@@ -219,19 +206,7 @@ void main() {
   late MethodDefinition qtgmcMethod;
 
   setUpAll(() async {
-    // Verify prerequisites
-    for (final check in <String, String>{
-      'Worker': TestConfig.workerPath,
-      'Input': TestConfig.inputFile,
-    }.entries) {
-      if (!await File(check.value).exists()) {
-        throw StateError('${check.key} not found at ${check.value}');
-      }
-    }
-    if (!await Directory(TestConfig.depsDir).exists()) {
-      throw StateError('Deps not found at ${TestConfig.depsDir}');
-    }
-
+    await WorkerHarness.ensureReady();
     await Directory(TestConfig.outputDir).create(recursive: true);
 
     // Load the deinterlace filter schema (same JSON the UI loads at runtime)
@@ -537,6 +512,13 @@ void main() {
         }
       }
 
+      // On macOS the worker auto-enables OpenCL when EdiMode is nnedi3-compatible
+      // (ZNEDI3/NNEDI3 lack NEON on Apple Silicon — see script_generator.rs), so
+      // `opencl=True` legitimately appears even in basic mode. Not a leak there.
+      if (Platform.isMacOS) {
+        unexpectedVsNames.remove('opencl');
+      }
+
       // The always-present params are those with explicit non-null values
       // in the base QTGMCParameters: Preset, TFF, FPSDivisor.
       // (InputType defaults to 0 but is stored as a non-optional int with
@@ -608,7 +590,10 @@ void main() {
         print('    $sectionLabel: ${entry.key} = ${entry.value}'
             '${isOptional ? ' [OPTIONAL]' : ''}');
 
-        // Every param in the script should be non-optional
+        // macOS auto-enables opencl (see above); it is optional but expected.
+        if (Platform.isMacOS && entry.key == 'opencl') continue;
+
+        // Every other param in the script should be non-optional
         expect(isOptional, isFalse,
             reason: '${entry.key} is optional and should not be in the '
                 'basic-mode script');

--- a/app/test/integration_video_trimming_test.dart
+++ b/app/test/integration_video_trimming_test.dart
@@ -3,41 +3,36 @@
 /// the output video to the expected length and that frames differ across
 /// the output (not just repeating the same frame).
 ///
-/// Run with: flutter test integration_test/video_trimming_test.dart
-/// Or: dart test integration_test/video_trimming_test.dart --chain-stack-traces
+/// Run headless via CI: flutter test test/integration_video_trimming_test.dart
+/// Heavy (full-encode) — tagged so it runs in the nightly workflow, not the push gate.
+@Tags(['heavy'])
+library;
+
+// ignore_for_file: avoid_print — these tests print diagnostics to the test log.
 
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:uuid/uuid.dart';
 
-import '../lib/models/encoding_settings.dart';
-import '../lib/models/qtgmc_parameters.dart';
-import '../lib/models/processing_pipeline.dart';
-import '../lib/models/video_job.dart';
+import 'package:vapourbox/models/encoding_settings.dart';
+import 'package:vapourbox/models/qtgmc_parameters.dart';
+import 'package:vapourbox/models/processing_pipeline.dart';
+import 'package:vapourbox/models/video_job.dart';
 
-/// Test configuration
+import 'support/worker_harness.dart';
+
+/// Thin shim over [WorkerHarness] so the test bodies keep their `TestConfig.*`
+/// call sites while paths/env resolve cross-platform.
 class TestConfig {
-  static final String projectRoot = _findProjectRoot();
-  static String get inputFile => '$projectRoot/Tests/TestResources/interlaced_test.avi';
-  static String get outputDir => '$projectRoot/Tests/TestOutput/trimming';
-  static String get workerPath => '$projectRoot/worker/target/release/vapourbox-worker.exe';
-  static String get depsDir => '$projectRoot/deps/windows-x64';
-
-  static String _findProjectRoot() {
-    var dir = Directory.current;
-    while (!File('${dir.path}/CLAUDE.md').existsSync()) {
-      final parent = dir.parent;
-      if (parent.path == dir.path) {
-        throw StateError('Could not find project root (looking for CLAUDE.md)');
-      }
-      dir = parent;
-    }
-    return dir.path.replaceAll('\\', '/');
-  }
+  static String get projectRoot => WorkerHarness.repoRoot;
+  static String get inputFile => WorkerHarness.inputFile;
+  static String get outputDir => '${WorkerHarness.outputDir}/trimming';
+  static String get workerPath => WorkerHarness.workerPath;
+  static String get depsDir => WorkerHarness.depsDir;
 }
 
 // =============================================================================
@@ -71,7 +66,7 @@ class VideoStreamInfo {
 
 /// Get detailed information about video streams using ffprobe
 Future<VideoStreamInfo> getVideoStreamInfo(String videoPath) async {
-  final ffprobePath = '${TestConfig.depsDir}/ffmpeg/ffprobe.exe';
+  final ffprobePath = WorkerHarness.ffprobePath;
 
   final result = await Process.run(
     ffprobePath,
@@ -84,7 +79,7 @@ Future<VideoStreamInfo> getVideoStreamInfo(String videoPath) async {
       videoPath,
     ],
     environment: {
-      'PATH': '${TestConfig.depsDir}/ffmpeg;${Platform.environment['PATH']}',
+      'PATH': '${WorkerHarness.depsDir}/ffmpeg${Platform.isWindows ? ';' : ':'}${Platform.environment['PATH']}',
     },
   );
 
@@ -129,7 +124,7 @@ Future<VideoStreamInfo> getVideoStreamInfo(String videoPath) async {
 Future<String> extractFrameHash(String videoPath, int frameNumber) async {
   final tempDir = Directory.systemTemp;
   final framePath = '${tempDir.path}/frame_${DateTime.now().millisecondsSinceEpoch}_$frameNumber.png';
-  final ffmpegPath = '${TestConfig.depsDir}/ffmpeg/ffmpeg.exe';
+  final ffmpegPath = WorkerHarness.ffmpegPath;
 
   try {
     final result = await Process.run(
@@ -142,7 +137,7 @@ Future<String> extractFrameHash(String videoPath, int frameNumber) async {
         framePath,
       ],
       environment: {
-        'PATH': '${TestConfig.depsDir}/ffmpeg;${Platform.environment['PATH']}',
+        'PATH': '${WorkerHarness.depsDir}/ffmpeg${Platform.isWindows ? ';' : ':'}${Platform.environment['PATH']}',
       },
     );
 
@@ -215,14 +210,8 @@ Future<FilterTestResult> runFilterTest(String testName, VideoJob job, {
   final configFile = File('${Directory.systemTemp.path}/job_${job.id}.json');
   await configFile.writeAsString(jsonEncode(job.toJson()));
 
-  // Set up environment
-  final env = Map<String, String>.from(Platform.environment);
-  final depsDir = TestConfig.depsDir;
-
-  env['PYTHONHOME'] = '$depsDir/vapoursynth';
-  env['PYTHONPATH'] = '$depsDir/vapoursynth/Lib/site-packages';
-  env['PATH'] = '$depsDir/vapoursynth;$depsDir/ffmpeg;${env['PATH']}';
-  env['VAPOURSYNTH_PLUGIN_PATH'] = '$depsDir/vapoursynth/vs-plugins';
+  // Cross-platform worker environment sourced from the shared harness.
+  final env = WorkerHarness.workerEnv;
 
   try {
     print('\n${'=' * 60}');
@@ -375,33 +364,8 @@ void main() {
 
   // Ensure output directory exists
   setUpAll(() async {
-    final outputDir = Directory(TestConfig.outputDir);
-    if (!await outputDir.exists()) {
-      await outputDir.create(recursive: true);
-    }
-
-    // Verify worker exists
-    final workerFile = File(TestConfig.workerPath);
-    if (!await workerFile.exists()) {
-      throw StateError(
-        'Worker not found at ${TestConfig.workerPath}\n'
-        'Run: cd worker && cargo build --release'
-      );
-    }
-
-    // Verify input file exists
-    final inputFile = File(TestConfig.inputFile);
-    if (!await inputFile.exists()) {
-      throw StateError(
-        'Test input file not found at ${TestConfig.inputFile}'
-      );
-    }
-
-    print('Test configuration:');
-    print('  Project root: ${TestConfig.projectRoot}');
-    print('  Input file: ${TestConfig.inputFile}');
-    print('  Output dir: ${TestConfig.outputDir}');
-    print('  Worker: ${TestConfig.workerPath}');
+    await WorkerHarness.ensureReady();
+    await Directory(TestConfig.outputDir).create(recursive: true);
   });
 
   group('Video Trimming Tests', () {

--- a/app/test/support/worker_harness.dart
+++ b/app/test/support/worker_harness.dart
@@ -1,0 +1,654 @@
+// Shared cross-platform harness for the integration tests in `app/test/`.
+//
+// These tests spawn the real `vapourbox-worker` binary (which runs
+// `vspipe | ffmpeg`) and inspect the output with `ffprobe`. They run headless
+// under `flutter test` on every CI platform — they render no Flutter UI, so
+// they live in `test/` (not `integration_test/`, which routes through the
+// device launcher).
+//
+// This harness consolidates everything the tests used to duplicate in a
+// per-file `TestConfig`: locating the deps bundle, the worker, and ffmpeg/
+// ffprobe; building the per-OS environment; and (new) DOWNLOADING the pinned
+// deps release when the bundle is absent, so the tests are self-sufficient.
+//
+// Deps resolution order (see [ensureReady]):
+//   1. $VAPOURBOX_DEPS_DIR  — set by CI, points straight at deps/<platform>.
+//   2. <repoRoot>/deps/<platform>  — populated by Scripts/download-deps-*.
+//   3. Download the version pinned in app/assets/deps-version.json into
+//      <repoRoot>/deps/<platform> (skip with $VAPOURBOX_SKIP_DEPS_DOWNLOAD=1).
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
+
+// DepsVersionInfo (URL/filename derivation) and platformId are pure helpers —
+// importing this file does NOT initialize the app's rhttp HTTP client, which is
+// why the harness does its own dart:io download below (rhttp's native bindings
+// don't load under the headless `flutter test` VM).
+import 'package:vapourbox/services/dependency_manager.dart'
+    show DepsVersionInfo, DependencyManager;
+
+/// Static entry point used by every integration test's `setUpAll`/helpers.
+class WorkerHarness {
+  WorkerHarness._();
+
+  static bool _ready = false;
+  static String? _repoRoot;
+  static String? _depsDir;
+  static String? _workerPath;
+
+  /// True once [ensureReady] has resolved deps + worker + input successfully.
+  static bool get ready => _ready;
+
+  // ---------------------------------------------------------------------------
+  // Paths (mirror the old per-file TestConfig surface)
+  // ---------------------------------------------------------------------------
+
+  static const _exe = '';
+
+  /// The repo root (directory containing CLAUDE.md), found by walking up from
+  /// the current working directory (`app/` under `flutter test`).
+  static String get repoRoot => _repoRoot ??= _findRepoRoot();
+
+  /// Resolved platform-specific deps directory, e.g. `deps/macos-arm64`.
+  /// Only valid after [ensureReady]; throws otherwise.
+  static String get depsDir {
+    final d = _depsDir;
+    if (d == null) {
+      throw StateError('Deps not resolved — call WorkerHarness.ensureReady() in setUpAll');
+    }
+    return d;
+  }
+
+  /// Platform identifier, e.g. `windows-x64`, `macos-arm64`, `linux-x64`.
+  static String get platform => DependencyManager.instance.platformId;
+
+  /// Path to the vapourbox-worker binary (release preferred, then debug).
+  static String get workerPath {
+    final w = _workerPath;
+    if (w == null) {
+      throw StateError('Worker not resolved — call WorkerHarness.ensureReady() in setUpAll');
+    }
+    return w;
+  }
+
+  static String get _ext => Platform.isWindows ? '.exe' : _exe;
+
+  /// Path to the bundled ffmpeg executable.
+  static String get ffmpegPath => p.join(depsDir, 'ffmpeg', 'ffmpeg$_ext');
+
+  /// Path to the bundled ffprobe executable.
+  static String get ffprobePath => p.join(depsDir, 'ffmpeg', 'ffprobe$_ext');
+
+  /// The interlaced test fixture used by most filter tests.
+  static String get inputFile =>
+      p.join(repoRoot, 'Tests', 'TestResources', 'interlaced_test.avi');
+
+  /// Directory test outputs are written to.
+  static String get outputDir => p.join(repoRoot, 'Tests', 'TestOutput');
+
+  // ---------------------------------------------------------------------------
+  // Whisper add-on (subtitle tests) — optional, provisioned separately
+  // ---------------------------------------------------------------------------
+
+  /// Directory the whisper add-on lives in, if resolvable.
+  static String? get _addonsDir {
+    final override = Platform.environment['VAPOURBOX_ADDONS_DIR'];
+    if (override != null && override.isNotEmpty && Directory(override).existsSync()) {
+      return override;
+    }
+    final repoAddons = p.join(repoRoot, 'addons');
+    if (Directory(repoAddons).existsSync()) return repoAddons;
+    return null;
+  }
+
+  /// Whether the whisper add-on (whisper-cli) is available. Subtitle tests that
+  /// run the full pipeline must skip when this is false (local dev w/o add-on).
+  static bool get whisperAvailable {
+    final dir = _addonsDir;
+    if (dir == null) return false;
+    final cli = p.join(dir, 'whisper', 'whisper-cli$_ext');
+    return File(cli).existsSync() ||
+        File(p.join(dir, 'whisper', 'whisper-cli')).existsSync();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Environments
+  // ---------------------------------------------------------------------------
+
+  /// Fresh environment map for spawning the worker (PYTHON*, VAPOURSYNTH_*,
+  /// PATH, and DYLD/LD_LIBRARY_PATH). Mirrors `ToolLocator._buildWorkerEnvironment`.
+  static Map<String, String> get workerEnv {
+    final env = Map<String, String>.from(Platform.environment);
+    final d = depsDir;
+
+    if (Platform.isWindows) {
+      env['PYTHONHOME'] = p.join(d, 'vapoursynth');
+      env['PYTHONPATH'] = p.join(d, 'vapoursynth', 'Lib', 'site-packages');
+      env['VAPOURSYNTH_PLUGIN_PATH'] = p.join(d, 'vapoursynth', 'vs-plugins');
+      final paths = [p.join(d, 'vapoursynth'), p.join(d, 'ffmpeg')];
+      env['PATH'] = '${paths.join(';')};${env['PATH'] ?? ''}';
+    } else {
+      final bundledPython = Directory(p.join(d, 'python'));
+      if (bundledPython.existsSync()) {
+        env['PYTHONHOME'] = p.join(d, 'python');
+      }
+      env['PYTHONPATH'] = p.join(d, 'python-packages');
+      env['PYTHONNOUSERSITE'] = '1';
+      env['VAPOURSYNTH_PLUGIN_PATH'] = p.join(d, 'vapoursynth', 'plugins');
+
+      final paths = <String>[];
+      if (bundledPython.existsSync()) paths.add(p.join(d, 'python', 'bin'));
+      paths.add(p.join(d, 'vapoursynth'));
+      paths.add(p.join(d, 'ffmpeg'));
+      env['PATH'] = '${paths.join(':')}:${env['PATH'] ?? ''}';
+
+      final libVar = Platform.isMacOS ? 'DYLD_LIBRARY_PATH' : 'LD_LIBRARY_PATH';
+      final libPaths = [
+        p.join(d, 'vapoursynth'),
+        p.join(d, 'python', 'lib'),
+        if (Platform.isLinux) p.join(d, 'lib'),
+      ];
+      final existing = env[libVar] ?? '';
+      env[libVar] =
+          existing.isEmpty ? libPaths.join(':') : '${libPaths.join(':')}:$existing';
+    }
+    return env;
+  }
+
+  /// Fresh environment map for invoking ffmpeg/ffprobe directly (just needs the
+  /// ffmpeg dir on PATH for any sibling libs).
+  static Map<String, String> get ffmpegEnv {
+    final env = Map<String, String>.from(Platform.environment);
+    final sep = Platform.isWindows ? ';' : ':';
+    env['PATH'] = '${p.join(depsDir, 'ffmpeg')}$sep${env['PATH'] ?? ''}';
+    return env;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Readiness — call from setUpAll
+  // ---------------------------------------------------------------------------
+
+  /// Resolve (and if necessary download) the deps bundle, locate the worker and
+  /// the input fixture, and create the output dir. Throws with an actionable
+  /// message if anything required cannot be obtained.
+  static Future<void> ensureReady() async {
+    if (_ready) return;
+
+    _depsDir = await _resolveDepsDir();
+    if (_depsDir == null) {
+      throw StateError(
+        'VapourSynth deps unavailable for platform "$platform".\n'
+        'Provision them with one of:\n'
+        '  - Scripts/download-deps-${_scriptSuffix()}\n'
+        '  - set VAPOURBOX_DEPS_DIR to an existing deps/<platform> directory\n'
+        '  - allow the harness to download (unset VAPOURBOX_SKIP_DEPS_DOWNLOAD; needs network).',
+      );
+    }
+
+    _workerPath = _resolveWorker();
+    if (_workerPath == null) {
+      throw StateError(
+        'vapourbox-worker not found under worker/target/{release,debug}.\n'
+        'Build it first: (cd worker && cargo build)',
+      );
+    }
+
+    if (!File(inputFile).existsSync()) {
+      throw StateError('Test input not found at $inputFile');
+    }
+
+    final out = Directory(outputDir);
+    if (!out.existsSync()) out.createSync(recursive: true);
+
+    // ignore: avoid_print
+    print('WorkerHarness: platform=$platform\n'
+        '  deps=$_depsDir\n  worker=$_workerPath\n  input=$inputFile');
+    _ready = true;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Worker invocation
+  // ---------------------------------------------------------------------------
+
+  /// Run a full encode job through the worker. Pass the job as JSON
+  /// (`job.toJson()`) so the harness stays independent of the app's models.
+  static Future<JobResult> runJob(
+    Map<String, dynamic> jobJson, {
+    String label = 'job',
+    Duration timeout = const Duration(minutes: 5),
+  }) async {
+    final id = jobJson['id']?.toString() ?? 'job';
+    final stopwatch = Stopwatch()..start();
+    final logs = <String>[];
+    final configFile = File(p.join(Directory.systemTemp.path, 'vb_$id.json'));
+    await configFile.writeAsString(jsonEncode(jobJson));
+
+    try {
+      final process = await Process.start(
+        workerPath,
+        ['--config', configFile.path],
+        environment: workerEnv,
+        workingDirectory: File(workerPath).parent.path,
+      );
+
+      String? outputPath;
+      bool? jobSuccess;
+      String? errorMessage;
+
+      process.stdout
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .listen((line) {
+        if (line.trim().isEmpty) return;
+        logs.add(line);
+        try {
+          final json = jsonDecode(line) as Map<String, dynamic>;
+          switch (json['type'] as String?) {
+            case 'complete':
+              jobSuccess = json['success'] as bool?;
+              outputPath = json['outputPath'] as String?;
+            case 'error':
+              errorMessage = json['message'] as String?;
+          }
+        } catch (_) {/* non-JSON log line */}
+      });
+      process.stderr
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .listen((line) => logs.add('[stderr] $line'));
+
+      final exitCode = await process.exitCode.timeout(
+        timeout,
+        onTimeout: () {
+          process.kill();
+          throw TimeoutException('$label timed out after ${timeout.inSeconds}s');
+        },
+      );
+      stopwatch.stop();
+
+      if (exitCode == 0 && jobSuccess == true) {
+        return JobResult(
+          success: true,
+          outputPath: outputPath,
+          duration: stopwatch.elapsed,
+          logs: logs,
+          exitCode: exitCode,
+        );
+      }
+      return JobResult(
+        success: false,
+        error: errorMessage ?? 'Worker exited with code $exitCode',
+        duration: stopwatch.elapsed,
+        logs: logs,
+        exitCode: exitCode,
+      );
+    } catch (e) {
+      stopwatch.stop();
+      return JobResult(
+        success: false,
+        error: e.toString(),
+        duration: stopwatch.elapsed,
+        logs: logs,
+      );
+    } finally {
+      await configFile.delete().catchError((_) => configFile);
+    }
+  }
+
+  /// Run the worker just far enough to emit the generated `.vpy`, then kill it
+  /// and return the script contents. The worker writes the script before vspipe
+  /// starts, so we poll for it.
+  static Future<String> generateScript(
+    Map<String, dynamic> jobJson, {
+    Duration pollFor = const Duration(seconds: 30),
+  }) async {
+    final id = jobJson['id']?.toString() ?? 'job';
+    final configFile = File(p.join(Directory.systemTemp.path, 'vb_script_$id.json'));
+    await configFile.writeAsString(jsonEncode(jobJson));
+    final scriptPath = p.join(Directory.systemTemp.path, '$id.vpy');
+
+    final process = await Process.start(
+      workerPath,
+      ['--config', configFile.path],
+      environment: workerEnv,
+      workingDirectory: File(workerPath).parent.path,
+    );
+
+    final logLines = <String>[];
+    process.stdout.transform(utf8.decoder).listen((data) {
+      for (final line in data.split('\n').where((l) => l.trim().isNotEmpty)) {
+        logLines.add(line);
+      }
+    });
+    process.stderr.transform(utf8.decoder).listen((_) {});
+
+    String? scriptContent;
+    final attempts = (pollFor.inMilliseconds / 500).ceil();
+    for (var i = 0; i < attempts; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      final f = File(scriptPath);
+      if (await f.exists()) {
+        scriptContent = await f.readAsString();
+        break;
+      }
+      // If the worker already exited without writing the script, stop early.
+      if (logLines.any((l) => l.contains('"type":"error"'))) break;
+    }
+
+    process.kill();
+    await process.exitCode.timeout(const Duration(seconds: 5), onTimeout: () {
+      Process.killPid(process.pid, ProcessSignal.sigkill);
+      return -1;
+    });
+    await configFile.delete().catchError((_) => configFile);
+    final sf = File(scriptPath);
+    if (await sf.exists()) await sf.delete().catchError((_) => sf);
+
+    if (scriptContent == null) {
+      throw StateError('Script not generated at $scriptPath\n'
+          'Worker output:\n${logLines.join('\n')}');
+    }
+    return scriptContent;
+  }
+
+  // ---------------------------------------------------------------------------
+  // ffprobe / ffmpeg verification helpers
+  // ---------------------------------------------------------------------------
+
+  /// Run ffprobe and return decoded JSON.
+  static Future<Map<String, dynamic>> ffprobeJson(List<String> args) async {
+    final result = await Process.run(ffprobePath, args, environment: ffmpegEnv);
+    if (result.exitCode != 0) {
+      throw Exception('ffprobe failed: ${result.stderr}');
+    }
+    return jsonDecode(result.stdout as String) as Map<String, dynamic>;
+  }
+
+  /// First stream of [selector] (e.g. `a:0`, `v:0`) as a map, or null.
+  static Future<Map<String, dynamic>?> firstStream(
+    String videoPath, {
+    required String selector,
+    required List<String> entries,
+    bool countFrames = false,
+  }) async {
+    final json = await ffprobeJson([
+      '-v', 'error',
+      '-select_streams', selector,
+      if (countFrames) '-count_frames',
+      '-show_entries', 'stream=${entries.join(',')}',
+      '-of', 'json',
+      videoPath,
+    ]);
+    final streams = json['streams'] as List?;
+    if (streams == null || streams.isEmpty) return null;
+    return streams.first as Map<String, dynamic>;
+  }
+
+  /// Extract one frame as PNG and return its md5 hash.
+  static Future<String> frameHash(String videoPath, {int frame = 5}) async {
+    final framePath = p.join(Directory.systemTemp.path,
+        'vb_frame_${DateTime.now().microsecondsSinceEpoch}_$frame.png');
+    try {
+      final result = await Process.run(
+        ffmpegPath,
+        ['-i', videoPath, '-vf', 'select=eq(n\\,$frame)', '-vframes', '1', '-y', framePath],
+        environment: ffmpegEnv,
+      );
+      if (result.exitCode != 0) {
+        throw Exception('frame extract failed: ${result.stderr}');
+      }
+      final bytes = await File(framePath).readAsBytes();
+      return md5.convert(bytes).toString();
+    } finally {
+      final f = File(framePath);
+      if (await f.exists()) await f.delete().catchError((_) => f);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internals
+  // ---------------------------------------------------------------------------
+
+  static String _findRepoRoot() {
+    var dir = Directory.current;
+    while (!File(p.join(dir.path, 'CLAUDE.md')).existsSync()) {
+      final parent = dir.parent;
+      if (parent.path == dir.path) {
+        throw StateError('Could not find repo root (looking for CLAUDE.md)');
+      }
+      dir = parent;
+    }
+    return dir.path;
+  }
+
+  static String _scriptSuffix() {
+    if (Platform.isWindows) return 'windows.ps1';
+    if (Platform.isMacOS) return 'macos.sh';
+    return 'linux.sh';
+  }
+
+  /// Critical files that must exist for a deps dir to count as usable.
+  static List<String> _criticalFiles() {
+    if (Platform.isWindows) {
+      return ['vapoursynth/VSPipe.exe', 'vapoursynth/vs-plugins', 'ffmpeg/ffmpeg.exe'];
+    }
+    return ['vapoursynth/vspipe', 'vapoursynth/plugins', 'ffmpeg/ffmpeg'];
+  }
+
+  static bool _depsValid(String dir) {
+    if (!Directory(dir).existsSync()) return false;
+    for (final f in _criticalFiles()) {
+      final fp = p.join(dir, f.replaceAll('/', p.separator));
+      if (!File(fp).existsSync() && !Directory(fp).existsSync()) return false;
+    }
+    return true;
+  }
+
+  static Future<String?> _resolveDepsDir() async {
+    // 1. Explicit override (CI).
+    final override = Platform.environment['VAPOURBOX_DEPS_DIR'];
+    if (override != null && override.isNotEmpty && _depsValid(override)) {
+      return override;
+    }
+
+    // 2. Repo-local deps/<platform>.
+    final local = p.join(repoRoot, 'deps', platform);
+    if (_depsValid(local)) return local;
+
+    // 3. Download the pinned release into deps/<platform>.
+    if (Platform.environment['VAPOURBOX_SKIP_DEPS_DOWNLOAD'] == '1') return null;
+    // ignore: avoid_print
+    print('WorkerHarness: deps missing — downloading pinned release for $platform…');
+    try {
+      await _downloadDeps(local);
+    } catch (e) {
+      // ignore: avoid_print
+      print('WorkerHarness: deps download failed: $e');
+      return null;
+    }
+    return _depsValid(local) ? local : null;
+  }
+
+  static String? _resolveWorker() {
+    final name = 'vapourbox-worker$_ext';
+    // Prefer debug: it's the dev/CI canonical build (`cargo test`/`cargo build`
+    // produce it), and preferring release would let a stale release binary
+    // shadow a freshly-built debug one.
+    for (final build in ['debug', 'release']) {
+      final candidate = p.join(repoRoot, 'worker', 'target', build, name);
+      if (File(candidate).existsSync()) return candidate;
+    }
+    return null;
+  }
+
+  static DepsVersionInfo _loadDepsVersion() {
+    final file = File(p.join(repoRoot, 'app', 'assets', 'deps-version.json'));
+    final json = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+    return DepsVersionInfo.fromJson(json);
+  }
+
+  /// Download + extract the pinned deps zip into [destDir].
+  static Future<void> _downloadDeps(String destDir) async {
+    final info = _loadDepsVersion();
+    final url = info.getDownloadUrl(platform);
+    final expectedSha = await _fetchSidecarSha(info.getManifestUrl(platform));
+
+    final tmp = await Directory.systemTemp.createTemp('vb_deps_');
+    final zip = File(p.join(tmp.path, info.filenameFor(platform)));
+    try {
+      // ignore: avoid_print
+      print('WorkerHarness: downloading $url');
+      final bytes = await _httpGetBytes(url);
+      if (expectedSha != null) {
+        final actual = sha256.convert(bytes).toString();
+        if (actual != expectedSha) {
+          throw StateError('deps sha256 mismatch (expected $expectedSha, got $actual)');
+        }
+      }
+      await zip.writeAsBytes(bytes);
+
+      final dest = Directory(destDir);
+      if (dest.existsSync()) dest.deleteSync(recursive: true);
+      dest.createSync(recursive: true);
+
+      final archive = ZipDecoder().decodeBytes(bytes);
+      for (final f in archive) {
+        final outPath = p.join(destDir, f.name);
+        if (f.isFile) {
+          final outFile = File(outPath);
+          outFile.parent.createSync(recursive: true);
+          outFile.writeAsBytesSync(f.content as List<int>);
+          if (!Platform.isWindows && _isExecutable(f.name)) {
+            await Process.run('chmod', ['+x', outPath]);
+          }
+        } else {
+          Directory(outPath).createSync(recursive: true);
+        }
+      }
+
+      if (Platform.isMacOS) {
+        await Process.run('xattr', ['-cr', destDir]);
+        // Ad-hoc re-sign dylibs/.so + known executables (Gatekeeper on Sequoia+).
+        await Process.run('/bin/sh', [
+          '-c',
+          'find "\$1" -type f \\( -name "*.dylib" -o -name "*.so" \\) '
+              '-exec codesign --force --sign - {} \\; 2>/dev/null',
+          '--',
+          destDir,
+        ]);
+        for (final exe in ['ffmpeg/ffmpeg', 'ffmpeg/ffprobe', 'vapoursynth/vspipe-bin']) {
+          final f = p.join(destDir, exe);
+          if (File(f).existsSync()) {
+            await Process.run('codesign', ['--force', '--sign', '-', f]);
+          }
+        }
+      }
+
+      // Stamp installed version so a normal app run treats it as up-to-date.
+      File(p.join(destDir, 'version.json')).writeAsStringSync(
+        const JsonEncoder.withIndent('  ').convert({
+          'version': info.versionFor(platform),
+          'installedAt': DateTime.now().toIso8601String(),
+        }),
+      );
+    } finally {
+      try {
+        tmp.deleteSync(recursive: true);
+      } catch (_) {}
+    }
+  }
+
+  static bool _isExecutable(String fileName) {
+    final name = p.basename(fileName).toLowerCase();
+    return name == 'ffmpeg' ||
+        name == 'ffprobe' ||
+        name == 'vspipe' ||
+        name == 'vspipe-bin' ||
+        name.endsWith('.sh') ||
+        !name.contains('.');
+  }
+
+  static Future<String?> _fetchSidecarSha(String url) async {
+    try {
+      final bytes = await _httpGetBytes(url);
+      final json = jsonDecode(utf8.decode(bytes)) as Map<String, dynamic>;
+      final sha = json['sha256'] as String?;
+      return (sha != null && sha.isNotEmpty) ? sha : null;
+    } catch (_) {
+      return null; // best-effort: install without hash check (HTTPS-trusted)
+    }
+  }
+
+  /// GET [url] following redirects manually so a GitHub auth token is only sent
+  /// to github.com hosts (and stripped on the redirect to the CDN). Works for
+  /// public release assets anonymously; honors $GH_TOKEN / $GITHUB_TOKEN for
+  /// private repos.
+  static Future<List<int>> _httpGetBytes(String url) async {
+    final token =
+        Platform.environment['GH_TOKEN'] ?? Platform.environment['GITHUB_TOKEN'];
+    final client = HttpClient()..connectionTimeout = const Duration(seconds: 30);
+    try {
+      var current = Uri.parse(url);
+      for (var redirects = 0; redirects < 6; redirects++) {
+        final request = await client.getUrl(current);
+        request.followRedirects = false;
+        final isGitHub = current.host.endsWith('github.com');
+        if (token != null && isGitHub) {
+          request.headers.set(HttpHeaders.authorizationHeader, 'Bearer $token');
+        }
+        request.headers.set(HttpHeaders.acceptHeader, 'application/octet-stream');
+        final response = await request.close();
+
+        if (response.isRedirect) {
+          final loc = response.headers.value(HttpHeaders.locationHeader);
+          await response.drain<void>();
+          if (loc == null) throw StateError('redirect without Location ($current)');
+          current = current.resolve(loc);
+          continue;
+        }
+        if (response.statusCode != 200) {
+          await response.drain<void>();
+          throw HttpException('HTTP ${response.statusCode} for $current');
+        }
+        final builder = BytesBuilder(copy: false);
+        await for (final chunk in response) {
+          builder.add(chunk);
+        }
+        return builder.takeBytes();
+      }
+      throw StateError('too many redirects for $url');
+    } finally {
+      client.close(force: true);
+    }
+  }
+}
+
+/// Result of a full encode [WorkerHarness.runJob].
+class JobResult {
+  final bool success;
+  final String? outputPath;
+  final String? error;
+  final Duration duration;
+  final List<String> logs;
+  final int? exitCode;
+
+  JobResult({
+    required this.success,
+    this.outputPath,
+    this.error,
+    required this.duration,
+    required this.logs,
+    this.exitCode,
+  });
+
+  @override
+  String toString() => success
+      ? 'SUCCESS in ${duration.inSeconds}s -> $outputPath'
+      : 'FAILED: $error (exit code: $exitCode)';
+}


### PR DESCRIPTION
## Context

The 7 Flutter integration tests in `app/integration_test/` never ran in CI for three compounding reasons: they lived under `integration_test/` (Flutter routes that through the device launcher, excluded from the `flutter test` gate), were hardcoded **Windows-only** (`package:test`, `deps/windows-x64`, `.exe`), and had drifted stale (`filter_pipeline` referenced removed APIs and didn't compile).

This makes them headless + cross-platform, updates them to the current parameter surface, adds the previously-missing passes, and wires them into CI.

## Changes

- **Shared harness** `app/test/support/worker_harness.dart`: cross-platform resolution of deps/worker/ffmpeg/ffprobe + per-OS worker env, and **self-downloads the pinned deps release** (`deps-version.json`) when absent — using `dart:io` (the app's `rhttp` doesn't init headless), with sha256 sidecar verification, macOS quarantine/codesign, `$GH_TOKEN` support. Honors `$VAPOURBOX_DEPS_DIR` (CI), opt out with `$VAPOURBOX_SKIP_DEPS_DOWNLOAD`.
- **Migrated all 7 tests** → `app/test/integration_*_test.dart`: `flutter_test`, route through the harness, drop per-file `TestConfig`/env duplication.
- **Fixed stale APIs** in `filter_pipeline` (`vinverseScl` removed; `audioCopy`→`audioMode`; `audioCodec`/`audioBitrate`→enums) and a flawed audio-hash helper (now hashes raw PCM, not the WAV container). Updated the qtgmc basic-mode test for the documented macOS auto-OpenCL default.
- **New coverage** for descratch / spotless / subtitles: script-gen tests in the gate + full-encode smoke tests in `integration_new_passes_test.dart`.
- **CI gating split:** `app/dart_test.yaml` declares a `heavy` tag; the push gate runs `flutter test --exclude-tags heavy` (script-only, fast); new `nightly.yml` runs `--tags heavy` (full encode) on the same 4-platform matrix.
- **`CLAUDE.md`** updated so future plugin changes must update these now-CI'd tests.

## Validation (local, against a real deps bundle)

- Gate (script-only): `integration_filter_parameters` (9 incl. new descratch/spotless) + `integration_qtgmc_parameters` — pass.
- Heavy: `integration_new_passes`, `integration_interlacing_status` (11), `integration_filter_pipeline` Audio group (8) — pass.
- `flutter analyze test/` clean (4 pre-existing `info` style lints only).

### Caveat
`filter_pipeline`'s frame-diff / preview-diff heavy tests couldn't be validated on my machine: the local deps decode the lagarith fixture as **1 frame** (input has 75), so frame-5 extraction has nothing to read — a local deps/codec issue, not a test defect (`select=eq(n\,0)` works; a fresh worker behaves the same). These are nightly-only and will be verified by the nightly run against the published deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)