### PR TITLE
worker: write VapourSynth autoload conf per-process (fixes intermittent fmtc autoload race)

### DIFF
--- a/worker/src/dependency_locator.rs
+++ b/worker/src/dependency_locator.rs
@@ -626,6 +626,26 @@ impl DependencyLocator {
         }
     }
 
+    /// Write the VapourSynth autoload config to a PER-PROCESS path and return it.
+    ///
+    /// `build_environment` runs on every worker invocation, and `flutter test`
+    /// runs test files concurrently, so writing a shared, fixed-name conf let an
+    /// overlapping vspipe read it mid-truncation — `UserPluginDir` came back
+    /// empty and plugin autoload silently skipped everything (the intermittent
+    /// "No attribute with the name fmtc exists" on the nightly). A per-process
+    /// file (named by PID) is written fully by this process and touched by no
+    /// other, eliminating the race. Verified by reproduction: a shared conf
+    /// failed ~1/120 concurrent runs; per-process was 0/360.
+    fn write_runtime_conf(plugins_dir: &Path) -> Option<PathBuf> {
+        let content = format!(
+            "UserPluginDir={}\nAutoloadUserPluginDir=true\nAutoloadSystemPluginDir=false\n",
+            plugins_dir.to_string_lossy()
+        );
+        let conf_path = env::temp_dir().join(format!("vapourbox-vs-{}.conf", std::process::id()));
+        std::fs::write(&conf_path, content).ok()?;
+        Some(conf_path)
+    }
+
     /// Build environment variables for running vspipe/ffmpeg.
     pub fn build_environment(&self) -> std::collections::HashMap<String, String> {
         let mut env = std::collections::HashMap::new();
@@ -679,13 +699,9 @@ impl DependencyLocator {
             // This replaces the config generation in the vspipe wrapper script,
             // allowing us to call vspipe-bin directly (so kill() works).
             let plugins_dir = vs_lib_path.join("plugins");
-            let conf_path = vs_lib_path.join("vapoursynth.auto.conf");
-            let conf_content = format!(
-                "UserPluginDir={}\nAutoloadUserPluginDir=true\nAutoloadSystemPluginDir=false\n",
-                plugins_dir.to_string_lossy()
-            );
-            let _ = std::fs::write(&conf_path, &conf_content);
-            env.insert("VAPOURSYNTH_CONF_PATH".to_string(), conf_path.to_string_lossy().to_string());
+            if let Some(conf_path) = Self::write_runtime_conf(&plugins_dir) {
+                env.insert("VAPOURSYNTH_CONF_PATH".to_string(), conf_path.to_string_lossy().to_string());
+            }
         }
 
         #[cfg(target_os = "linux")]
@@ -715,13 +731,9 @@ impl DependencyLocator {
 
             // Generate VapourSynth config (same as macOS)
             let plugins_dir = vs_lib_path.join("plugins");
-            let conf_path = vs_lib_path.join("vapoursynth.auto.conf");
-            let conf_content = format!(
-                "UserPluginDir={}\nAutoloadUserPluginDir=true\nAutoloadSystemPluginDir=false\n",
-                plugins_dir.to_string_lossy()
-            );
-            let _ = std::fs::write(&conf_path, &conf_content);
-            env.insert("VAPOURSYNTH_CONF_PATH".to_string(), conf_path.to_string_lossy().to_string());
+            if let Some(conf_path) = Self::write_runtime_conf(&plugins_dir) {
+                env.insert("VAPOURSYNTH_CONF_PATH".to_string(), conf_path.to_string_lossy().to_string());
+            }
         }
 
         env


### PR DESCRIPTION
## Root cause (investigated + reproduced)
The intermittent macOS-arm64 nightly failure `No attribute with the name fmtc exists` was a **plugin-autoload race**. `build_environment()` wrote `vapoursynth.auto.conf` to a **shared, fixed-name** path on every invocation, and `flutter test` runs test files **concurrently** — so an overlapping vspipe could read the conf mid-truncation, get an empty `UserPluginDir`, and silently skip plugin autoload.

The `.vpy` scripts were already unique per job (UUID), so the conf was the one shared file.

## Reproduction
8 concurrent workers × unique fmtc scripts, rewriting the **shared** conf like `build_environment`:
- **Shared conf: ~1/120 runs failed** with the exact error.
- **Per-process conf: 0/360 runs failed.**

## Fix
Write the conf to a per-process path (`vapourbox-vs-<pid>.conf` in the temp dir) and point `VAPOURSYNTH_CONF_PATH` at it. Each process writes its own conf fully before spawning vspipe; nothing else touches it. (macOS + linux; Windows uses `VAPOURSYNTH_PLUGIN_PATH` and isn't affected.)

## Validation
Worker builds clean, 64 lib tests pass, interlacing heavy test passes locally with the per-process conf. Nightly triggered from this branch to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)