### PR TITLE
ci: bump actions to Node 24 majors (@v5)

### DIFF
--- a/.github/workflows/build-deps-linux.yml
+++ b/.github/workflows/build-deps-linux.yml
@@ -29,7 +29,7 @@ jobs:
     if: ${{ inputs.arch == 'x64' || inputs.arch == 'both' }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install build dependencies
         run: |
@@ -47,7 +47,7 @@ jobs:
       - name: Package dependencies
         run: ./Scripts/package-deps-linux.sh --version "${{ inputs.version }}" --arch x64
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: VapourBox-deps-${{ inputs.version }}-linux-x64
           path: |
@@ -67,7 +67,7 @@ jobs:
     if: ${{ inputs.arch == 'arm64' || inputs.arch == 'both' }}
     runs-on: ubuntu-22.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install build dependencies
         run: |
@@ -85,7 +85,7 @@ jobs:
       - name: Package dependencies
         run: ./Scripts/package-deps-linux.sh --version "${{ inputs.version }}" --arch arm64
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: VapourBox-deps-${{ inputs.version }}-linux-arm64
           path: |

--- a/.github/workflows/build-deps-macos.yml
+++ b/.github/workflows/build-deps-macos.yml
@@ -36,7 +36,7 @@ jobs:
     if: ${{ inputs.arch == 'arm64' || inputs.arch == 'both' }}
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build dependencies (arm64, native)
         run: ./Scripts/download-deps-macos.sh --force
@@ -44,7 +44,7 @@ jobs:
       - name: Package dependencies
         run: ./Scripts/package-deps-macos.sh --version "${{ inputs.version }}" --arch arm64
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: VapourBox-deps-${{ inputs.version }}-macos-arm64
           path: |
@@ -64,7 +64,7 @@ jobs:
     if: ${{ inputs.arch == 'x64' || inputs.arch == 'both' }}
     runs-on: macos-15-intel  # only hosted Intel image (macos-13 retired; last one until ~Aug 2027)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build dependencies (x64, native)
         # STRICT_MIN_OS=1: fail the build if any bundled Mach-O targets newer than
@@ -76,7 +76,7 @@ jobs:
       - name: Package dependencies
         run: ./Scripts/package-deps-macos.sh --version "${{ inputs.version }}" --arch x64
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: VapourBox-deps-${{ inputs.version }}-macos-x64
           path: |

--- a/.github/workflows/build-deps-windows.yml
+++ b/.github/workflows/build-deps-windows.yml
@@ -25,7 +25,7 @@ jobs:
   build-x64:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build dependencies
         shell: pwsh
@@ -35,7 +35,7 @@ jobs:
         shell: pwsh
         run: ./Scripts/package-deps-windows.ps1 -Version "${{ inputs.version }}"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: VapourBox-deps-${{ inputs.version }}-windows-x64
           path: |

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install system dependencies
         run: |
@@ -48,7 +48,7 @@ jobs:
           targets: x86_64-unknown-linux-gnu
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -110,7 +110,7 @@ jobs:
           ./Scripts/package-linux.sh --version "${{ inputs.version }}" --arch x64 --skip-build
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: VapourBox-${{ inputs.version }}-linux-x64
           path: dist/VapourBox-${{ inputs.version }}-linux-x64.tar.gz
@@ -121,7 +121,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install system dependencies
         run: |
@@ -146,7 +146,7 @@ jobs:
           targets: aarch64-unknown-linux-gnu
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -208,7 +208,7 @@ jobs:
           ./Scripts/package-linux.sh --version "${{ inputs.version }}" --arch arm64 --skip-build
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: VapourBox-${{ inputs.version }}-linux-arm64
           path: dist/VapourBox-${{ inputs.version }}-linux-arm64.tar.gz

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Resolve arch variables
         id: arch
@@ -82,7 +82,7 @@ jobs:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -240,7 +240,7 @@ jobs:
           security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db" 2>/dev/null || true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: VapourBox-${{ inputs.version }}-macos-${{ matrix.arch }}
           path: dist/VapourBox-${{ inputs.version }}-macos-${{ matrix.arch }}.dmg

--- a/.github/workflows/build-whisper.yml
+++ b/.github/workflows/build-whisper.yml
@@ -72,7 +72,7 @@ jobs:
           echo "size=$(stat -c%s whisper-cli-linux-x64.tar.gz)"
           echo "sha256=$(sha256sum whisper-cli-linux-x64.tar.gz | cut -d' ' -f1)"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: whisper-cli-linux-x64
           path: whisper-cli-linux-x64.tar.gz
@@ -129,7 +129,7 @@ jobs:
           echo "size=$(stat -c%s whisper-cli-linux-arm64.tar.gz)"
           echo "sha256=$(sha256sum whisper-cli-linux-arm64.tar.gz | cut -d' ' -f1)"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: whisper-cli-linux-arm64
           path: whisper-cli-linux-arm64.tar.gz

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -30,7 +30,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -180,7 +180,7 @@ jobs:
           Get-ChildItem -Path "dist/"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: VapourBox-${{ inputs.version }}-windows-x64
           path: dist/VapourBox-${{ inputs.version }}-windows-x64.zip

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -37,7 +37,7 @@ jobs:
       # (Platform.resolvedExecutable is the test runner under `flutter test`).
       VAPOURBOX_DEPS_DIR: ${{ github.workspace }}/deps/macos-${{ matrix.arch }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Resolve deps tag
         id: deps
@@ -69,7 +69,7 @@ jobs:
 
       # The whisper small model (~466 MB) is architecture-independent; cache it.
       - name: Cache whisper model
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .whisper-cache
           key: whisper-ggml-small-v1
@@ -109,7 +109,7 @@ jobs:
     env:
       VAPOURBOX_DEPS_DIR: ${{ github.workspace }}/deps/windows-x64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Resolve deps tag
         id: deps
@@ -143,7 +143,7 @@ jobs:
           rm -f "$ZIP"
 
       - name: Cache whisper model
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .whisper-cache
           key: whisper-ggml-small-v1
@@ -186,7 +186,7 @@ jobs:
       # not (it uses the XDG path), so we also symlink it below.
       VAPOURBOX_DEPS_DIR: ${{ github.workspace }}/deps/linux-x64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install system dependencies
         run: |
@@ -222,7 +222,7 @@ jobs:
           rm -f "$ZIP"
 
       - name: Cache whisper model
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .whisper-cache
           key: whisper-ggml-small-v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,7 +43,7 @@ jobs:
     env:
       VAPOURBOX_DEPS_DIR: ${{ github.workspace }}/deps/macos-${{ matrix.arch }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Resolve deps tag
         id: deps
@@ -74,7 +74,7 @@ jobs:
           xattr -cr deps/macos-${{ matrix.arch }} 2>/dev/null || true
 
       - name: Cache whisper model
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .whisper-cache
           key: whisper-ggml-small-v1
@@ -109,7 +109,7 @@ jobs:
     env:
       VAPOURBOX_DEPS_DIR: ${{ github.workspace }}/deps/windows-x64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Resolve deps tag
         id: deps
@@ -141,7 +141,7 @@ jobs:
           rm -f "$ZIP"
 
       - name: Cache whisper model
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .whisper-cache
           key: whisper-ggml-small-v1
@@ -179,7 +179,7 @@ jobs:
     env:
       VAPOURBOX_DEPS_DIR: ${{ github.workspace }}/deps/linux-x64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install system dependencies
         run: |
@@ -215,7 +215,7 @@ jobs:
           rm -f "$ZIP"
 
       - name: Cache whisper model
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .whisper-cache
           key: whisper-ggml-small-v1


### PR DESCRIPTION
Clears the **Node 20 deprecation warnings** in CI.

GitHub deprecated Node 20 on Actions runners — runners now default to Node 24, and actions still built on Node 20 emit:

> `Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v4, actions/checkout@v4`

## Change
Bump the GitHub-maintained actions off `@v4` (Node 20) to `@v5` (first Node-24 major) across all 9 workflow files:
- `actions/checkout@v4` → `@v5`
- `actions/cache@v4` → `@v5`
- `actions/upload-artifact@v4` → `@v5`

No `download-artifact` usage. `dtolnay/rust-toolchain` is a composite action (no Node); `subosito/flutter-action@v2` is unaffected.

## Validation note
The `ci-test.yml` gate on this PR exercises `checkout@v5` + `cache@v5` on all four platforms. `upload-artifact@v5` is only used by the `workflow_dispatch` build/deps workflows (not PR-triggered), so it's worth a manual `build-deps`/`build-macos` run to confirm — though v5 is a stable, widely-used release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)