### PR TITLE
Move VapourSynth from R73 to R78, and harden the deps install

### DIFF
--- a/.github/workflows/build-deps-linux.yml
+++ b/.github/workflows/build-deps-linux.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   build-x64:
     if: ${{ inputs.arch == 'x64' || inputs.arch == 'both' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
 
@@ -39,18 +39,12 @@ jobs:
             cython3 pkg-config gcc g++ python3-pip \
             libfftw3-dev libboost-filesystem-dev libboost-atomic-dev \
             ocl-icd-opencl-dev opencl-headers libdvdread-dev unzip
-          # VapourSynth R78 needs a C++ toolchain newer than jammy's default:
-          # src/core/float16_helper.h uses _Float16 in C++ (needs GCC >= 13) and
-          # averageframesfilter.cpp uses __builtin_roundevenf (needs clang >= 17).
-          # ubuntu-22.04 ships gcc 11 and has no gcc-13 in its repositories at
-          # all, so this comes from apt.llvm.org — the route already proven to
-          # work on jammy arm64. The rest of the deps build keeps using the
-          # system gcc; only VapourSynth needs the newer compiler, and
-          # download-deps-linux.sh picks it up if present.
-          wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
-          chmod +x /tmp/llvm.sh
-          sudo /tmp/llvm.sh 19
-          clang-19 --version | head -1
+          # ubuntu-24.04 ships gcc 13 and Cython 3, which is what VapourSynth
+          # R78 needs: float16_helper.h uses _Float16 in C++ (GCC >= 13),
+          # averageframesfilter.cpp uses __builtin_roundevenf, and
+          # vapoursynth.pyx uses Cython 3 syntax. On 22.04 none of those were
+          # available and each had to be worked around separately.
+          gcc --version | head -1
           pip3 install meson
 
       - name: Build dependencies
@@ -77,7 +71,7 @@ jobs:
 
   build-arm64:
     if: ${{ inputs.arch == 'arm64' || inputs.arch == 'both' }}
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v5
 
@@ -89,18 +83,12 @@ jobs:
             cython3 pkg-config gcc g++ python3-pip \
             libfftw3-dev libboost-filesystem-dev libboost-atomic-dev \
             ocl-icd-opencl-dev opencl-headers libdvdread-dev unzip
-          # VapourSynth R78 needs a C++ toolchain newer than jammy's default:
-          # src/core/float16_helper.h uses _Float16 in C++ (needs GCC >= 13) and
-          # averageframesfilter.cpp uses __builtin_roundevenf (needs clang >= 17).
-          # ubuntu-22.04 ships gcc 11 and has no gcc-13 in its repositories at
-          # all, so this comes from apt.llvm.org — the route already proven to
-          # work on jammy arm64. The rest of the deps build keeps using the
-          # system gcc; only VapourSynth needs the newer compiler, and
-          # download-deps-linux.sh picks it up if present.
-          wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
-          chmod +x /tmp/llvm.sh
-          sudo /tmp/llvm.sh 19
-          clang-19 --version | head -1
+          # ubuntu-24.04 ships gcc 13 and Cython 3, which is what VapourSynth
+          # R78 needs: float16_helper.h uses _Float16 in C++ (GCC >= 13),
+          # averageframesfilter.cpp uses __builtin_roundevenf, and
+          # vapoursynth.pyx uses Cython 3 syntax. On 22.04 none of those were
+          # available and each had to be worked around separately.
+          gcc --version | head -1
           pip3 install meson
 
       - name: Build dependencies

--- a/.github/workflows/build-deps-linux.yml
+++ b/.github/workflows/build-deps-linux.yml
@@ -40,14 +40,17 @@ jobs:
             libfftw3-dev libboost-filesystem-dev libboost-atomic-dev \
             ocl-icd-opencl-dev opencl-headers libdvdread-dev unzip
           # VapourSynth R78 needs a C++ toolchain newer than jammy's default:
-          # src/core/float16_helper.h uses _Float16 in C++ (GCC >= 13) and
-          # averageframesfilter.cpp uses __builtin_roundevenf (clang >= 17).
-          # ubuntu-22.04 ships gcc 11, which fails with
-          # "'_Float16' was not declared in this scope".
-          sudo apt-get install -y gcc-13 g++-13
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 130 \
-                                   --slave /usr/bin/g++ g++ /usr/bin/g++-13
-          gcc --version | head -1
+          # src/core/float16_helper.h uses _Float16 in C++ (needs GCC >= 13) and
+          # averageframesfilter.cpp uses __builtin_roundevenf (needs clang >= 17).
+          # ubuntu-22.04 ships gcc 11 and has no gcc-13 in its repositories at
+          # all, so this comes from apt.llvm.org — the route already proven to
+          # work on jammy arm64. The rest of the deps build keeps using the
+          # system gcc; only VapourSynth needs the newer compiler, and
+          # download-deps-linux.sh picks it up if present.
+          wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+          chmod +x /tmp/llvm.sh
+          sudo /tmp/llvm.sh 19
+          clang-19 --version | head -1
           pip3 install meson
 
       - name: Build dependencies
@@ -87,14 +90,17 @@ jobs:
             libfftw3-dev libboost-filesystem-dev libboost-atomic-dev \
             ocl-icd-opencl-dev opencl-headers libdvdread-dev unzip
           # VapourSynth R78 needs a C++ toolchain newer than jammy's default:
-          # src/core/float16_helper.h uses _Float16 in C++ (GCC >= 13) and
-          # averageframesfilter.cpp uses __builtin_roundevenf (clang >= 17).
-          # ubuntu-22.04 ships gcc 11, which fails with
-          # "'_Float16' was not declared in this scope".
-          sudo apt-get install -y gcc-13 g++-13
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 130 \
-                                   --slave /usr/bin/g++ g++ /usr/bin/g++-13
-          gcc --version | head -1
+          # src/core/float16_helper.h uses _Float16 in C++ (needs GCC >= 13) and
+          # averageframesfilter.cpp uses __builtin_roundevenf (needs clang >= 17).
+          # ubuntu-22.04 ships gcc 11 and has no gcc-13 in its repositories at
+          # all, so this comes from apt.llvm.org — the route already proven to
+          # work on jammy arm64. The rest of the deps build keeps using the
+          # system gcc; only VapourSynth needs the newer compiler, and
+          # download-deps-linux.sh picks it up if present.
+          wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+          chmod +x /tmp/llvm.sh
+          sudo /tmp/llvm.sh 19
+          clang-19 --version | head -1
           pip3 install meson
 
       - name: Build dependencies

--- a/.github/workflows/build-deps-linux.yml
+++ b/.github/workflows/build-deps-linux.yml
@@ -39,6 +39,15 @@ jobs:
             cython3 pkg-config gcc g++ python3-pip \
             libfftw3-dev libboost-filesystem-dev libboost-atomic-dev \
             ocl-icd-opencl-dev opencl-headers libdvdread-dev unzip
+          # VapourSynth R78 needs a C++ toolchain newer than jammy's default:
+          # src/core/float16_helper.h uses _Float16 in C++ (GCC >= 13) and
+          # averageframesfilter.cpp uses __builtin_roundevenf (clang >= 17).
+          # ubuntu-22.04 ships gcc 11, which fails with
+          # "'_Float16' was not declared in this scope".
+          sudo apt-get install -y gcc-13 g++-13
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 130 \
+                                   --slave /usr/bin/g++ g++ /usr/bin/g++-13
+          gcc --version | head -1
           pip3 install meson
 
       - name: Build dependencies
@@ -77,6 +86,15 @@ jobs:
             cython3 pkg-config gcc g++ python3-pip \
             libfftw3-dev libboost-filesystem-dev libboost-atomic-dev \
             ocl-icd-opencl-dev opencl-headers libdvdread-dev unzip
+          # VapourSynth R78 needs a C++ toolchain newer than jammy's default:
+          # src/core/float16_helper.h uses _Float16 in C++ (GCC >= 13) and
+          # averageframesfilter.cpp uses __builtin_roundevenf (clang >= 17).
+          # ubuntu-22.04 ships gcc 11, which fails with
+          # "'_Float16' was not declared in this scope".
+          sudo apt-get install -y gcc-13 g++-13
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 130 \
+                                   --slave /usr/bin/g++ g++ /usr/bin/g++-13
+          gcc --version | head -1
           pip3 install meson
 
       - name: Build dependencies

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -4,7 +4,7 @@ name: CI Tests
 # model) and runs the Rust test suite plus the Flutter tests, EXCLUDING the
 # heavy full-encode integration tests (those run in nightly.yml via
 # `--tags heavy`). macOS is tested natively on both arm64 (macos-15) and x64
-# (macos-15-intel); Windows on x64; Linux on x64 (ubuntu-22.04).
+# (macos-15-intel); Windows on x64; Linux on x64 (ubuntu-24.04).
 
 on:
   push:
@@ -180,7 +180,8 @@ jobs:
         run: cd app && flutter test --exclude-tags heavy
 
   linux:
-    runs-on: ubuntu-22.04  # matches the deps-build runner (glibc compatibility)
+    runs-on: ubuntu-24.04  # must match the deps-build runner: those binaries
+                       # need its glibc, so an older runner cannot run them
     env:
       # Dart ToolLocator/DependencyManager honour this; the Rust locator does
       # not (it uses the XDG path), so we also symlink it below.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -175,7 +175,7 @@ jobs:
 
   linux:
     if: ${{ github.event_name == 'schedule' || inputs.platform == 'all' || inputs.platform == 'linux' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04  # must match the deps-build runner (glibc)
     env:
       VAPOURBOX_DEPS_DIR: ${{ github.workspace }}/deps/linux-x64
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -902,6 +902,28 @@ matter more than usual (see `app/test/vapoursynth_integration_test.dart`).
 > would `AttributeError`. Only reachable with `Denoiser='knlmeanscl'` **and**
 > `ChromaNoise=True` (both non-default), so it has never been hit.
 
+### No source-indexing plugin is bundled
+
+Sources are read as **raw frames piped from ffmpeg** (`templates/pipe_source.py`),
+so nothing in the product opens a file through a VapourSynth source filter.
+
+FFMS2 went first, replaced by **BestSource**; then the pipe source replaced that,
+and BestSource stayed in the macOS bundle for years afterwards calling itself
+"bundled for parity" — parity with nothing, since Windows and Linux never shipped
+it. Removed 2026-08-07: no `core.bs.` call site existed anywhere in the
+templates, worker, app or tests.
+
+It was worth removing rather than leaving alone. At **16.9 MB** it was four times
+the next largest plugin and about a sixth of the macOS deps zip, and it was the
+**only** consumer of `liblzma` — so it also carried the `xz` from-source build on
+x64, two `install_name_tool` repoint blocks (its arm64 build links the *system*
+liblzma, its x64 build Homebrew's), and their codesign steps, all of which went
+with it.
+
+If a source filter is ever needed again, add it back deliberately with a call
+site — don't reintroduce it into the preview path, which is pipe-source-based for
+frame-accuracy reasons.
+
 ### fmtconv's aarch64 integer scaler bug (fixed by our own patch)
 
 **Symptom.** `fmtc.resample` returned **black** whenever fmtconv's integer kernel
@@ -1058,10 +1080,11 @@ version skew between platforms would change chroma per-OS.
   name; the harnesses were missed in the migration and only the Dart
   integration suite caught it.
 - Plugins in `deps/windows-x64/vapoursynth/vs-plugins/`, Python packages in `Lib/site-packages/`
-- BestSource (`core.bs`) is **not** in the Windows bundle — it is macOS-only, for
-  parity. Neither is plain `nnedi3`; Windows ships `znedi3` + `nnedi3cl`. The
-  authoritative required-namespace list is in
-  `app/test/vapoursynth_integration_test.dart`.
+- Plain `nnedi3` is **not** in the Windows bundle; it ships `znedi3` +
+  `nnedi3cl`. The authoritative required-namespace list is in
+  `app/test/vapoursynth_integration_test.dart` — check there before "fixing" an
+  apparently missing plugin. **BestSource is no longer bundled anywhere** (see
+  "No source-indexing plugin" below).
 - The script writes `deps/windows-x64/version.json` (as macOS and Linux do).
   Without it the app reports "Version file missing" on startup and downloads the
   **published** bundle over the local one — which silently restored R73 over a
@@ -1074,7 +1097,7 @@ version skew between platforms would change chroma per-OS.
 - Fully self-contained deps (no Homebrew at runtime): Python 3.12 (python-build-standalone), VS built from source
 - Worker sets: `PYTHONHOME`, `PYTHONPATH`, `VAPOURSYNTH_CONF_PATH`, `DYLD_LIBRARY_PATH`
 - `vspipe` is a wrapper script that generates config dynamically (needed because `VAPOURSYNTH_PLUGIN_PATH` is additive, not a replacement)
-- **FFmpeg** is sourced pre-built as a static binary that links only system frameworks: **x64** from evermeet.cx, **arm64** from martin-riedl.de (Homebrew's arm64 ffmpeg is dynamically linked to ~17 Homebrew dylibs and is NOT self-contained, so it can't be bundled). **x64 plugins** build from source under Rosetta, except `tmedian`/`bestsource` which come pre-built from Stefan-Olt/vs-plugin-build. **`zsmooth` is the one plugin built from source on x64 but taken pre-built on arm64**: the author's x86_64 binary is `minos 13.0` and this bundle targets 12.0, so the minos guard rejects it (it would fail to load on Monterey — exactly issue #39). It is written in Zig, so the x64 branch fetches a pinned Zig toolchain and builds with `-Dtarget=x86_64-macos.12.0`; `ZIG_VERSION` must satisfy zsmooth's `minimum_zig_version`, and the build needs network access for zsmooth's own Zig dependencies. arm64 keeps the pre-built binary, which is under its 15.0 target.
+- **FFmpeg** is sourced pre-built as a static binary that links only system frameworks: **x64** from evermeet.cx, **arm64** from martin-riedl.de (Homebrew's arm64 ffmpeg is dynamically linked to ~17 Homebrew dylibs and is NOT self-contained, so it can't be bundled). **x64 plugins** build from source under Rosetta, except `tmedian` which comes pre-built from Stefan-Olt/vs-plugin-build. **`zsmooth` is the one plugin built from source on x64 but taken pre-built on arm64**: the author's x86_64 binary is `minos 13.0` and this bundle targets 12.0, so the minos guard rejects it (it would fail to load on Monterey — exactly issue #39). It is written in Zig, so the x64 branch fetches a pinned Zig toolchain and builds with `-Dtarget=x86_64-macos.12.0`; `ZIG_VERSION` must satisfy zsmooth's `minimum_zig_version`, and the build needs network access for zsmooth's own Zig dependencies. arm64 keeps the pre-built binary, which is under its 15.0 target.
 - **x64 minimum macOS = 12.0 (Monterey), issue #39**: the only hosted Intel runner is `macos-15-intel` (`macos-13` was retired), so Homebrew bottles come out `minos 14/15` and won't load on 12. The x64 build therefore exports `MACOSX_DEPLOYMENT_TARGET=12.0` and **builds the bundled support libs from source** (zimg, fftw, libdvdread, xz, boost) so they target 12; the OpenCL plugins (`nnedi3cl`/`knlmeanscl`) are compiled against that source boost (`BOOST_ROOT="$SRCLIB"`) for ABI match. vspipe's `doubleToString` is patched off `std::to_chars` (needs 13.3+ libc++). A `minos` verification pass at the end fails the build under `STRICT_MIN_OS=1` (set in `build-deps-macos.yml`) if any bundled Mach-O exceeds 12.0. **arm64 is unchanged (still `minos 15`)** — it has no old runner and the prebuilt arm64 plugins are >12. The app/worker deployment target is **per-arch**: the x64 build targets **12.0** and the arm64 build targets **15.0** (matching its minos-15 deps). `build-macos.yml` resolves the target per matrix arch and threads it to rustc (`MACOSX_DEPLOYMENT_TARGET`) and xcodebuild (which overrides the `Runner.xcodeproj` 12.0 baseline); the `Podfile` reads `VAPOURBOX_DEPLOYMENT_TARGET` (default 12.0). `package-macos.sh` sets the same per-arch target for local builds.
 - **Code signing**: After `install_name_tool` modifications, binaries must be re-signed: `codesign -s - -f <binary>` (exit code 137 = SIGKILL means invalid signature)
 - Quarantine removal: `xattr -cr` on deps after download

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -811,6 +811,16 @@ Headless Dart-VM tests. Three groups:
   `_high_bit_depth_filters`, `_source_formats`, `_upscale_resize`,
   `_white_balance`.
 
+> **Feeding a test clip to vspipe's stdin: start draining stdout/stderr BEFORE
+> writing, and never `await` the write.** These scripts request a single frame,
+> so vspipe reads a fraction of the raw file and exits; awaiting `stdin.close()`
+> first deadlocks, because the write blocks on a pipe nobody is reading and the
+> drain that would let vspipe finish never starts. R73 hid this by spending
+> ~1.4s in script evaluation — long enough for the whole payload to land in the
+> OS pipe buffer. R78 evaluates in ~0.01s and lost the race every time, turning
+> all ten stdin-piping tests in `vapoursynth_integration_test.dart` into 30s
+> timeouts. It was always a race, not a version difference.
+
 `WorkerHarness` also runs the worker in **preview** mode (`runPreview`) and
 compares rendered frames (`imageToRgb24` + `meanAbsDiff`). Preview and encode are
 separate scripts *and* separate ffmpeg invocations, so a filter can render fine
@@ -1019,9 +1029,43 @@ version skew between platforms would change chroma per-OS.
 
 ### Windows
 
-- VapourSynth R73 portable uses Python 3.8 (not 3.11+)
-- Worker sets env vars via `DependencyLocator`: `PYTHONHOME`, `PYTHONPATH`, `VAPOURSYNTH_PLUGIN_PATH`, `PATH`
+- **VapourSynth R78 ships Windows purely as a Python wheel.**
+  `VapourSynth64-Portable-R78.zip` holds only `wheel\`, `vspipe.bat`, `pip.bat`
+  and docs — no `VSPipe.exe`, no DLLs, no Python. `download-deps-windows.ps1`
+  therefore follows upstream's own installer: unpack the **Python 3.12.10
+  embeddable**, add `Lib\site-packages` to its `._pth`, then expand the wheel
+  (a wheel is a zip, but `Expand-Archive` rejects the `.whl` extension, so it is
+  copied to a `.zip` name first).
+- Layout moved with it — anything hardcoding the old paths breaks silently:
+
+  | | R73 | R78 |
+  |---|---|---|
+  | Python | 3.8.10 embeddable | **3.12.10** embeddable (wheel is cp312-abi3) |
+  | vspipe | `vapoursynth\VSPipe.exe` | `vapoursynth\Lib\site-packages\vapoursynth\vspipe.exe` |
+  | plugin path var | `VAPOURSYNTH_PLUGIN_PATH` | **`VAPOURSYNTH_EXTRA_PLUGIN_PATH`** |
+  | core filters | inside `libvapoursynth` | separate `libvapoursynthfilters.dll` |
+  | vsscript | `VSScriptPython38.dll` | `vsscript.dll` (Python-version independent) |
+
+- `libvapoursynthfilters.dll` matters more than it looks: R78 moved **every core
+  filter** (`std`, `resize`, …) out of `libvapoursynth` into it, so a bundle
+  without it fails every job at script evaluation with missing namespaces.
+  `package-deps-windows.ps1` guards on it.
+- Worker sets env vars via `DependencyLocator`: `PYTHONHOME`, `PYTHONPATH`,
+  `VAPOURSYNTH_EXTRA_PLUGIN_PATH`, `PATH`. The old `VAPOURSYNTH_PLUGIN_PATH`
+  name is inert from R74 on — plugins are simply never autoloaded and every
+  filter dies with "No attribute with the name `<ns>` exists". `ToolLocator`
+  (Dart), `DependencyLocator` (Rust) and the test harnesses must all use the new
+  name; the harnesses were missed in the migration and only the Dart
+  integration suite caught it.
 - Plugins in `deps/windows-x64/vapoursynth/vs-plugins/`, Python packages in `Lib/site-packages/`
+- BestSource (`core.bs`) is **not** in the Windows bundle — it is macOS-only, for
+  parity. Neither is plain `nnedi3`; Windows ships `znedi3` + `nnedi3cl`. The
+  authoritative required-namespace list is in
+  `app/test/vapoursynth_integration_test.dart`.
+- The script writes `deps/windows-x64/version.json` (as macOS and Linux do).
+  Without it the app reports "Version file missing" on startup and downloads the
+  **published** bundle over the local one — which silently restored R73 over a
+  locally built R78 tree.
 - Show in Folder: `cmd /c explorer /select, <path>`
 
 ### macOS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -902,6 +902,41 @@ matter more than usual (see `app/test/vapoursynth_integration_test.dart`).
 > would `AttributeError`. Only reachable with `Denoiser='knlmeanscl'` **and**
 > `ChromaNoise=True` (both non-default), so it has never been hit.
 
+### R78: `deps/<platform>/vapoursynth/` IS the Python package (macOS/Linux)
+
+R78 ships VapourSynth as a Python package, and this is not cosmetic. `vsscript`
+resolves the Python library through a config file at
+`$XDG_CONFIG_HOME/vapoursynth/vapoursynth.toml`, **keyed by the absolute path of
+`libvsscript`**. That file is written by `vapoursynth config`, which records the
+`libvsscript` belonging to the *imported package*. So the copy `vspipe-bin`
+loads and the copy the module reports must be the same file, or every script
+dies with:
+
+> Python executable and library path couldn't be determined despite automatic
+> configuration. Run `vapoursynth config` ...
+
+Hence the layout: the libraries, `vapoursynth.abi3.so` and the pure-Python files
+(`__init__.py`, `_cli.py`, `_utils.py`, …) all live in
+`deps/<platform>/vapoursynth/`, and the **platform directory is on `PYTHONPATH`**
+so `import vapoursynth` resolves there. Four consequences:
+
+- **Ship the `.py` files too.** Without them `vapoursynth config` cannot run and
+  vsscript's automatic configuration has nothing to call.
+- **A `vapoursynth` shim goes in `python/bin/`.** vsscript self-configures by
+  literally running `system("vapoursynth config")`; a from-source build creates
+  no console script, so we provide one.
+- **`XDG_CONFIG_HOME` must point somewhere writable** (`deps/<platform>/config`).
+  The worker, the app and the vspipe wrapper all set it.
+- **Do not set `VAPOURSYNTH_EXTRA_PLUGIN_PATH` on macOS/Linux.** The plugins are
+  at `vapoursynth/plugins`, which is `<libdir>/plugins` — R78 autoloads it. With
+  both, every plugin loads twice and warns `Plugin ... already loaded`. Windows
+  still needs the variable: its plugins are in `vs-plugins`, which is not the
+  autoload directory.
+
+`_has_implicit_config()` returns true **only on Windows** (where `python.exe`
+sits next to the package), which is why the Windows bundle needs none of this and
+why a Windows-only test pass does not prove the Unix path works.
+
 ### No source-indexing plugin is bundled
 
 Sources are read as **raw frames piped from ffmpeg** (`templates/pipe_source.py`),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -856,7 +856,7 @@ Each job pulls the published deps bundle + the whisper add-on, then runs
 **suite #1 (`cargo test`) and suite #2 (`flutter test --exclude-tags heavy`)** —
 including the subtitle integration test, excluding the heavy full-encode
 integration tests. Matrix: macOS **arm64** (`macos-15`), macOS **x64**
-(`macos-15-intel`), **Windows x64**, **Linux x64** (`ubuntu-22.04`). Notes:
+(`macos-15-intel`), **Windows x64**, **Linux x64** (`ubuntu-24.04`). Notes:
 
 - whisper-cli is provisioned from the **same source the app uses at runtime**
   (`app/assets/whisper-addon.json`): macOS via a Homebrew bottle, Windows/Linux
@@ -901,6 +901,27 @@ matter more than usual (see `app/test/vapoursynth_integration_test.dart`).
 > `KNLMeansCL`'s `clip.format.color_family not in [vs.YUV, vs.YCOCG]` survives and
 > would `AttributeError`. Only reachable with `Denoiser='knlmeanscl'` **and**
 > `ChromaNoise=True` (both non-default), so it has never been hit.
+
+### Linux builds on ubuntu-24.04, and that sets the glibc floor
+
+The Linux **deps** builds and the runners that test against them
+(`ci-test.yml`, `nightly.yml`) all run on `ubuntu-24.04`. They must stay in
+step: the deps binaries need the glibc they were built against, so testing them
+on an older runner fails at load, and `ci-test.yml` carries a comment saying so.
+
+This was forced by R78. ubuntu-22.04 could not build it at all, and not for one
+reason but four, each only visible once the previous was cleared: no `_Float16`
+in C++ (needs GCC >= 13, jammy has 11 and no gcc-13 package), no
+`__builtin_roundevenf` under its clang, Cython 0.29 against a `.pyx` using
+Cython 3 syntax, and meson preferring the apt `cython3` over a pip-installed
+Cython 3. Noble ships all of it.
+
+**The cost is user-facing**: the bundle now needs **glibc 2.39**, so Ubuntu
+22.04 (2.35) and Debian 12 (2.36) can no longer run it. That is recorded in the
+README's platform table. The app and whisper builds deliberately stay on
+`ubuntu-22.04` — their binaries run on newer systems regardless, so a lower
+floor there costs nothing — but the effective requirement is the highest of the
+components, which is the deps.
 
 ### Testing a deps change before publishing: release-candidate tags
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -902,6 +902,38 @@ matter more than usual (see `app/test/vapoursynth_integration_test.dart`).
 > would `AttributeError`. Only reachable with `Denoiser='knlmeanscl'` **and**
 > `ChromaNoise=True` (both non-default), so it has never been hit.
 
+### Testing a deps change before publishing: release-candidate tags
+
+A PR that changes `deps/` has a chicken-and-egg problem: `ci-test.yml` and
+`nightly.yml` download the bundle named by `app/assets/deps-version.json` from a
+**published** release, so a deps change cannot be tested until it is published —
+and publishing an untested bundle is what you were trying to avoid.
+
+**Draft releases do not solve it** (their assets need an authenticated API call,
+so neither CI nor the app can fetch them). **Prereleases do**: they are publicly
+downloadable at the ordinary `releases/download/<tag>/<asset>` URL, and every
+consumer here is tag-driven — `getDownloadUrl()` builds the URL from
+`releaseTag`, and nothing in the repo uses `/releases/latest`. So a prerelease
+is indistinguishable from a stable release to CI, the nightly suite *and* a real
+app build.
+
+The workflow:
+
+1. `gh release create deps-vX.Y.Z-rc1 --prerelease` on the PR branch.
+2. Run the three `build-deps-*` workflows with `version: X.Y.Z-rc1` and
+   `release_tag: deps-vX.Y.Z-rc1`. They upload the zip and its `.sha256.json`
+   sidecar. (They also always upload a workflow artifact, so `release_tag` can
+   be left empty for a build-only run.)
+3. Point `deps-version.json` at the rc **on the PR branch only**.
+4. Iterate — rc bundles are disposable, because the rule about never reusing a
+   deps version only binds once a *released app* references one.
+5. Before merge, publish the final `deps-vX.Y.Z` and repoint.
+
+`Scripts/release.sh` refuses to cut an app release while `deps-version.json`
+names an `-rc` tag. That is the one way this bites: an rc escaping into a shipped
+build, where later deleting the prerelease breaks the download for everyone who
+installed it.
+
 ### Installing a deps bundle: staged, swapped, and version-directional
 
 `DependencyManager` **replaces** a bundle rather than merging into one, which is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -902,6 +902,38 @@ matter more than usual (see `app/test/vapoursynth_integration_test.dart`).
 > would `AttributeError`. Only reachable with `Denoiser='knlmeanscl'` **and**
 > `ChromaNoise=True` (both non-default), so it has never been hit.
 
+### Installing a deps bundle: staged, swapped, and version-directional
+
+`DependencyManager` **replaces** a bundle rather than merging into one, which is
+what makes a layout change like R73 → R78 safe: no `libvapoursynth-script`,
+`vapoursynth.conf`, `libbestsource`, `python38.*` or stale `VSPipe.exe` survives
+into the new install. (That last one matters — `dependency_locator.rs` keeps a
+deliberate fallback to the old top-level `VSPipe.exe`, so a leftover R73 binary
+could otherwise be picked up silently.)
+
+Three properties worth preserving if you touch this:
+
+- **Staged, then swapped.** The download is verified, extracted to
+  `<deps>.new`, checked with `executabilityProblem()` and stamped with its
+  `version.json` — and only then swapped in via two renames, with the old tree
+  moved to `<deps>.old` and deleted afterwards. It used to delete the live
+  install and extract over the top, which left the user with *nothing* if that
+  window was interrupted. If the second rename fails the first is undone.
+- **`version.json` is written last**, inside the staged tree. It is the commit
+  marker: a tree that never completed can never look valid.
+- **Direction is checked, not just equality.** Installed *newer* than expected
+  is `newerThanExpected` — kept, with a one-time warning at startup — not
+  `outdated`. Treating it as outdated downgraded a deliberately newer bundle,
+  and since installing wipes and replaces, that was destructive. Use
+  `compareVersions`, not `!=` or a string compare: `"1.10.0"` sorts before
+  `"1.9.0"` lexically.
+
+The critical-file list also includes a file that exists **only** in the R78
+layout (`libvapoursynthfilters`, plus `vapoursynth/__init__.py` on Unix).
+`vspipe`, `plugins/` and `ffmpeg` all exist in both layouts, so without an
+R78-only marker a stale tree carrying a newer `version.json` passes every check
+and fails later at job time.
+
 ### R78: `deps/<platform>/vapoursynth/` IS the Python package (macOS/Linux)
 
 R78 ships VapourSynth as a Python package, and this is not cosmetic. `vsscript`

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ VapourBox runs [VapourSynth](https://www.vapoursynth.com/), QTGMC and FFmpeg —
 | macOS (Apple Silicon) | macOS 15 Sequoia | `VapourBox-x.x.x-macos-arm64.dmg` |
 | macOS (Intel) | macOS 12 Monterey | `VapourBox-x.x.x-macos-x64.dmg` |
 | Windows (x64) | Windows 10/11 | `VapourBox-x.x.x-windows-x64.zip` |
-| Linux (x64) | — | `VapourBox-x.x.x-linux-x64.tar.gz` |
-| Linux (arm64) | — | `VapourBox-x.x.x-linux-arm64.tar.gz` |
+| Linux (x64) | glibc 2.39 (Ubuntu 24.04, Debian 13) | `VapourBox-x.x.x-linux-x64.tar.gz` |
+| Linux (arm64) | glibc 2.39 (Ubuntu 24.04, Debian 13) | `VapourBox-x.x.x-linux-arm64.tar.gz` |
 
 All processing is local. There is no account, no telemetry, and nothing is uploaded.
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Stuart Cameron — [stuart-cameron.com](https://stuart-cameron.com)
 macOS plugins and binaries sourced from:
 
 - **[yuygfgg/Macos_vapoursynth_plugins](https://github.com/yuygfgg/Macos_vapoursynth_plugins)** — pre-built ARM64 VapourSynth plugins for macOS
-- **[Stefan-Olt/vs-plugin-build](https://github.com/Stefan-Olt/vs-plugin-build)** — cross-platform VapourSynth plugins (arm64 + x86_64; used for `tmedian` and `bestsource`)
+- **[Stefan-Olt/vs-plugin-build](https://github.com/Stefan-Olt/vs-plugin-build)** — cross-platform VapourSynth plugins (arm64 + x86_64; used for `tmedian`)
 - **[evermeet.cx](https://evermeet.cx/ffmpeg/)** — static x86_64 FFmpeg/FFprobe builds for the Intel macOS bundle
 
 The Intel (x64) bundle additionally builds its support libraries (zimg, fftw, libdvdread, xz, boost) from source targeting **macOS 12**, so it runs on Monterey; the Apple Silicon (arm64) bundle is built for the current macOS and targets **macOS 15**.

--- a/Scripts/deps-expected-plugins.json
+++ b/Scripts/deps-expected-plugins.json
@@ -28,7 +28,6 @@
   "macos-arm64": [
     "libaddgrain.dylib",
     "libawarpsharp2.dylib",
-    "libbestsource.dylib",
     "libbm3d.dylib",
     "libcas.dylib",
     "libctmf.dylib",
@@ -56,7 +55,6 @@
   "macos-x64": [
     "libaddgrain.dylib",
     "libawarpsharp2.dylib",
-    "libbestsource.dylib",
     "libcas.dylib",
     "libctmf.dylib",
     "libdctfilter.dylib",

--- a/Scripts/download-deps-linux.sh
+++ b/Scripts/download-deps-linux.sh
@@ -153,16 +153,28 @@ fi
 echo ""
 echo "=== Building VapourSynth from source ==="
 
+VS_TAG="R78"
 VS_BUILD_DIR="$BUILD_DIR/vapoursynth"
 VS_INSTALL_DIR="$BUILD_DIR/vapoursynth-install"
 
 if [ "$FORCE" = true ] || [ ! -f "$DEPS_DIR/vapoursynth/libvapoursynth.so" ]; then
-    echo "  Cloning VapourSynth R73..."
+    echo "  Cloning VapourSynth $VS_TAG..."
     rm -rf "$VS_BUILD_DIR"
-    git clone --depth 1 --branch R73 https://github.com/vapoursynth/vapoursynth.git "$VS_BUILD_DIR" 2>/dev/null || \
+    git clone --depth 1 --branch "$VS_TAG" https://github.com/vapoursynth/vapoursynth.git "$VS_BUILD_DIR" 2>/dev/null || \
     git clone --depth 1 https://github.com/vapoursynth/vapoursynth.git "$VS_BUILD_DIR"
 
     cd "$VS_BUILD_DIR"
+
+    # zimg API guard (backport of upstream 37eed3dd). R78 reads zimg's
+    # chromatic_adaptation field unconditionally, but it only exists in a zimg
+    # newer than the current release, so R78 builds against no released zimg.
+    # See the patch header. Hard-fail rather than die in the compiler.
+    git apply "$SCRIPT_DIR/patches/vapoursynth-r78-zimg-api-guard.patch" || {
+        echo "  ERROR: patches/vapoursynth-r78-zimg-api-guard.patch did not apply." >&2
+        echo "  If VapourSynth has moved past R78 the fix is already upstream — drop it." >&2
+        exit 1
+    }
+    echo "  Applied the zimg chromatic_adaptation API guard"
 
     # Install Cython in our embedded Python for building
     echo "  Installing Cython in embedded Python..."
@@ -222,15 +234,25 @@ EOF
 
     echo "  Copying VapourSynth files..."
     # Copy vspipe
-    cp "$VS_INSTALL_DIR/bin/vspipe" "$DEPS_DIR/vapoursynth/vspipe-bin"
+    # Copy from the build directory, not the install prefix: R74 turned
+    # VapourSynth into a Python package, so `ninja install` puts everything
+    # under <prefix>/<python-site-packages>/vapoursynth/ instead of bin/ and
+    # lib/. The build directory is flat and Python-independent.
+    VS_BUILT="$VS_BUILD_DIR/build"
+
+    cp "$VS_BUILT/vspipe" "$DEPS_DIR/vapoursynth/vspipe-bin"
     chmod +x "$DEPS_DIR/vapoursynth/vspipe-bin"
 
     # Copy libraries
-    cp "$VS_INSTALL_DIR/lib/libvapoursynth.so"* "$DEPS_DIR/vapoursynth/"
-    cp "$VS_INSTALL_DIR/lib/libvapoursynth-script.so"* "$DEPS_DIR/vapoursynth/"
+    cp "$VS_BUILT/libvapoursynth.so"* "$DEPS_DIR/vapoursynth/"
+    # vapoursynth-script was renamed vsscript in R78.
+    cp "$VS_BUILT/libvsscript.so"* "$DEPS_DIR/vapoursynth/"
+    # R78 split every core filter (std, resize, ...) out of libvapoursynth into
+    # this module; without it the core namespaces are absent and every job fails.
+    cp "$VS_BUILT/libvapoursynthfilters.so"* "$DEPS_DIR/vapoursynth/"
 
     # Copy Python module
-    find "$VS_BUILD_DIR/build" -name "vapoursynth*.so" -exec cp {} "$PYTHON_PACKAGES_DIR/" \;
+    cp "$VS_BUILT/vapoursynth.abi3.so" "$PYTHON_PACKAGES_DIR/"
 
     # Fix RPATHs
     echo "  Fixing RPATHs..."
@@ -255,19 +277,12 @@ export VAPOURSYNTH_PLUGIN_PATH="$SCRIPT_DIR/plugins"
 export PYTHONPATH="$DEPS_ROOT/python-packages:${PYTHONPATH:-}"
 export LD_LIBRARY_PATH="$SCRIPT_DIR:$DEPS_ROOT/python/lib:$DEPS_ROOT/lib:${LD_LIBRARY_PATH:-}"
 
-# Generate config dynamically with correct absolute path
-CONF_FILE=$(mktemp)
-cat > "$CONF_FILE" << EOF
-UserPluginDir=$SCRIPT_DIR/plugins
-AutoloadUserPluginDir=true
-AutoloadSystemPluginDir=false
-EOF
-export VAPOURSYNTH_CONF_PATH="$CONF_FILE"
+# R74 removed the config-file mechanism entirely (UserPluginDir /
+# AutoloadUserPluginDir / VAPOURSYNTH_CONF_PATH no longer exist). Plugins come
+# from <libdir>/plugins plus this variable.
+export VAPOURSYNTH_EXTRA_PLUGIN_PATH="$SCRIPT_DIR/plugins"
 
-"$SCRIPT_DIR/vspipe-bin" "$@"
-EXIT_CODE=$?
-rm -f "$CONF_FILE"
-exit $EXIT_CODE
+exec "$SCRIPT_DIR/vspipe-bin" "$@"
 WRAPPER_EOF
     chmod +x "$DEPS_DIR/vapoursynth/vspipe"
 

--- a/Scripts/download-deps-linux.sh
+++ b/Scripts/download-deps-linux.sh
@@ -213,6 +213,21 @@ EOF
         cp "$BUILD_PREFIX/lib/pkgconfig/zimg.pc" "$BUILD_DIR/pkgconfig/"
     fi
 
+    # meson looks for a "cython3" program before "cython", so apt's cython3
+    # (0.29 on jammy) wins over the Cython 3.x we just installed into the
+    # embedded interpreter no matter how PATH is ordered — and R78's
+    # vapoursynth.pyx uses Cython 3 syntax, failing with "Syntax error in C
+    # variable declaration" on `noexcept`. Provide both names as wrappers that
+    # run the module, which also sidesteps the console script's baked-in
+    # shebang (it points at the machine that built the interpreter).
+    for cy in cython cython3; do
+        cat > "$PYTHON_DIR/bin/$cy" << CYEOF
+#!/bin/bash
+exec "$PYTHON_DIR/bin/python3" -m cython "\$@"
+CYEOF
+        chmod +x "$PYTHON_DIR/bin/$cy"
+    done
+
     # R78 needs a newer C++ toolchain than Ubuntu 22.04's default gcc 11:
     # float16_helper.h uses _Float16 in C++ and averageframesfilter.cpp uses
     # __builtin_roundevenf. Use a newer clang for VapourSynth alone if one is

--- a/Scripts/download-deps-linux.sh
+++ b/Scripts/download-deps-linux.sh
@@ -220,9 +220,7 @@ EOF
     meson setup build \
         --prefix="$VS_INSTALL_DIR" \
         --buildtype=release \
-        -Dlibdir=lib \
-        -Dplugindir="" \
-        -Dpython3_bin="$PYTHON_BIN"
+        -Dlibdir=lib
 
     echo "  Building VapourSynth..."
     PATH="$PYTHON_DIR/bin:$PATH" \

--- a/Scripts/download-deps-linux.sh
+++ b/Scripts/download-deps-linux.sh
@@ -287,16 +287,16 @@ exec "$DEPS_ROOT/python/bin/python3" -m vapoursynth "$@"
 SHIM_EOF
     chmod +x "$PYTHON_DIR/bin/vapoursynth"
 
-    # Copy Python module
-
     # Fix RPATHs
     echo "  Fixing RPATHs..."
     patchelf --set-rpath '$ORIGIN' "$DEPS_DIR/vapoursynth/vspipe-bin"
     for lib in "$DEPS_DIR/vapoursynth"/libvapoursynth*.so*; do
         [ -f "$lib" ] && [ ! -L "$lib" ] && patchelf --set-rpath '$ORIGIN:$ORIGIN/../python/lib' "$lib" 2>/dev/null || true
     done
-    for so_file in "$PYTHON_PACKAGES_DIR"/vapoursynth*.so; do
-        [ -f "$so_file" ] && patchelf --set-rpath '$ORIGIN/../vapoursynth:$ORIGIN/../python/lib' "$so_file" 2>/dev/null || true
+    # The extension module sits in vapoursynth/ now, beside the libraries it
+    # loads, so $ORIGIN alone reaches them.
+    for so_file in "$DEPS_DIR/vapoursynth"/vapoursynth*.so; do
+        [ -f "$so_file" ] && patchelf --set-rpath '$ORIGIN:$ORIGIN/../python/lib' "$so_file" 2>/dev/null || true
     done
 
     # Create wrapper script (same concept as macOS)
@@ -326,8 +326,18 @@ WRAPPER_EOF
     chmod +x "$DEPS_DIR/vapoursynth/vspipe"
 
     # Copy VS headers to deps for plugin builds (persists across runs)
+    # R78 installs the headers inside the Python package rather than under
+    # <prefix>/include/vapoursynth, so locate them instead of assuming. Plugin
+    # builds resolve VapourSynth through these, so a wrong path here means most
+    # of the plugin set silently fails to configure.
     mkdir -p "$DEPS_DIR/vapoursynth/include"
-    cp "$VS_INSTALL_DIR/include/vapoursynth/"*.h "$DEPS_DIR/vapoursynth/include/"
+    VS_HDR_DIR="$(dirname "$(find "$VS_INSTALL_DIR" -name 'VapourSynth4.h' 2>/dev/null | head -1)")"
+    if [ -n "$VS_HDR_DIR" ] && [ -d "$VS_HDR_DIR" ]; then
+        cp "$VS_HDR_DIR/"*.h "$DEPS_DIR/vapoursynth/include/"
+    else
+        echo "  ERROR: could not locate VapourSynth headers under $VS_INSTALL_DIR" >&2
+        exit 1
+    fi
 
     cd "$BUILD_DIR"
     echo "  Built VapourSynth from source with embedded Python"
@@ -355,7 +365,7 @@ includedir=\${prefix}/include
 
 Name: VapourSynth
 Description: VapourSynth
-Version: 73
+Version: 78
 Libs: -L\${libdir} -lvapoursynth
 Cflags: -I\${includedir}
 EOF

--- a/Scripts/download-deps-linux.sh
+++ b/Scripts/download-deps-linux.sh
@@ -178,7 +178,7 @@ if [ "$FORCE" = true ] || [ ! -f "$DEPS_DIR/vapoursynth/libvapoursynth.so" ]; th
 
     # Install Cython in our embedded Python for building
     echo "  Installing Cython in embedded Python..."
-    "$PYTHON_BIN" -m pip install --quiet cython
+    "$PYTHON_BIN" -m pip install --quiet cython meson
 
     # Create pkg-config file for our embedded Python
     mkdir -p "$BUILD_DIR/pkgconfig"
@@ -217,7 +217,16 @@ EOF
     PATH="$PYTHON_DIR/bin:$PATH" \
     PKG_CONFIG_PATH="$BUILD_DIR/pkgconfig:$BUILD_PREFIX/lib/pkgconfig" \
     LD_LIBRARY_PATH="$PYTHON_DIR/lib:$BUILD_PREFIX/lib:${LD_LIBRARY_PATH:-}" \
-    meson setup build \
+    # Run meson with the EMBEDDED python, not whatever meson happens to be
+    # installed under. R78 locates Python with
+    # `import('python').find_installation()`, which resolves to the interpreter
+    # meson itself is running as — PATH does not influence it, and the
+    # -Dpython3_bin option that used to override it was removed. Left alone,
+    # meson picks the runner's system python: on Linux that has no development
+    # headers, so configuration dies with "Header 'Python.h' could not be
+    # found", and on macOS it silently builds and installs against Homebrew's
+    # python instead of the one we ship.
+    "$PYTHON_BIN" -m mesonbuild.mesonmain setup build \
         --prefix="$VS_INSTALL_DIR" \
         --buildtype=release \
         -Dlibdir=lib

--- a/Scripts/download-deps-linux.sh
+++ b/Scripts/download-deps-linux.sh
@@ -306,12 +306,25 @@ CYEOF
     # PYTHONPATH satisfies that without moving anything the app knows about, and
     # leaves the plugins at <libdir>/plugins where R78 autoloads them — so no
     # plugin path variable is set here; with both, plugins load twice.
-    cp "$VS_BUILT/libvapoursynth.so"* "$DEPS_DIR/vapoursynth/"
-    # vapoursynth-script was renamed vsscript in R78.
-    cp "$VS_BUILT/libvsscript.so"* "$DEPS_DIR/vapoursynth/"
-    # R78 split every core filter (std, resize, ...) out of libvapoursynth into
-    # this module; without it the core namespaces are absent and every job fails.
-    cp "$VS_BUILT/libvapoursynthfilters.so"* "$DEPS_DIR/vapoursynth/"
+    # Copy the libraries and their symlinks, skipping meson's private
+    # "<target>.p" build directories — a bare `cp libvapoursynth.so*` matches
+    # those too and fails with "-r not specified; omitting directory".
+    # vapoursynth-script was renamed vsscript in R78, and libvapoursynthfilters
+    # is new: it holds every core filter (std, resize, ...), so without it the
+    # core namespaces are absent and every job fails at script evaluation.
+    for pattern in libvapoursynth.so libvsscript.so libvapoursynthfilters.so; do
+        found=false
+        for f in "$VS_BUILT/$pattern"*; do
+            [ -e "$f" ] || continue
+            [ -d "$f" ] && continue
+            cp -a "$f" "$DEPS_DIR/vapoursynth/"
+            found=true
+        done
+        if [ "$found" = false ]; then
+            echo "  ERROR: no $pattern* built in $VS_BUILT" >&2
+            exit 1
+        fi
+    done
     cp "$VS_BUILT/vapoursynth.abi3.so" "$DEPS_DIR/vapoursynth/"
     # The pure-Python half of the package; without it `vapoursynth config`
     # cannot run and vsscript's automatic configuration has nothing to call.

--- a/Scripts/download-deps-linux.sh
+++ b/Scripts/download-deps-linux.sh
@@ -213,8 +213,30 @@ EOF
         cp "$BUILD_PREFIX/lib/pkgconfig/zimg.pc" "$BUILD_DIR/pkgconfig/"
     fi
 
+    # R78 needs a newer C++ toolchain than Ubuntu 22.04's default gcc 11:
+    # float16_helper.h uses _Float16 in C++ and averageframesfilter.cpp uses
+    # __builtin_roundevenf. Use a newer clang for VapourSynth alone if one is
+    # installed, leaving every other component on the system compiler. Fail
+    # loudly rather than dying later inside a confusing template error.
+    VS_CC=""; VS_CXX=""
+    for v in 19 18 17; do
+        if command -v "clang-$v" >/dev/null 2>&1; then
+            VS_CC="clang-$v"; VS_CXX="clang++-$v"; break
+        fi
+    done
+    if [ -z "$VS_CC" ]; then
+        GCC_MAJOR=$(gcc -dumpversion 2>/dev/null | cut -d. -f1)
+        if [ -z "$GCC_MAJOR" ] || [ "$GCC_MAJOR" -lt 13 ]; then
+            echo "  ERROR: VapourSynth $VS_TAG needs clang >= 17 or GCC >= 13." >&2
+            echo "  Found gcc ${GCC_MAJOR:-unknown} and no suitable clang." >&2
+            exit 1
+        fi
+    fi
+    [ -n "$VS_CC" ] && echo "  Using $VS_CC for VapourSynth"
+
     echo "  Configuring VapourSynth..."
     PATH="$PYTHON_DIR/bin:$PATH" \
+    ${VS_CC:+CC="$VS_CC"} ${VS_CXX:+CXX="$VS_CXX"} \
     PKG_CONFIG_PATH="$BUILD_DIR/pkgconfig:$BUILD_PREFIX/lib/pkgconfig" \
     LD_LIBRARY_PATH="$PYTHON_DIR/lib:$BUILD_PREFIX/lib:${LD_LIBRARY_PATH:-}" \
     # Run meson with the EMBEDDED python, not whatever meson happens to be
@@ -334,6 +356,13 @@ WRAPPER_EOF
     VS_HDR_DIR="$(dirname "$(find "$VS_INSTALL_DIR" -name 'VapourSynth4.h' 2>/dev/null | head -1)")"
     if [ -n "$VS_HDR_DIR" ] && [ -d "$VS_HDR_DIR" ]; then
         cp "$VS_HDR_DIR/"*.h "$DEPS_DIR/vapoursynth/include/"
+        # R78 installs only the API4 headers, but several plugins still include
+        # <VapourSynth.h> (API3). They remain in the source tree.
+        for hdr in "$VS_BUILD_DIR/include/"*.h; do
+            [ -f "$hdr" ] || continue
+            [ -f "$DEPS_DIR/vapoursynth/include/$(basename "$hdr")" ] || \
+                cp "$hdr" "$DEPS_DIR/vapoursynth/include/"
+        done
     else
         echo "  ERROR: could not locate VapourSynth headers under $VS_INSTALL_DIR" >&2
         exit 1

--- a/Scripts/download-deps-linux.sh
+++ b/Scripts/download-deps-linux.sh
@@ -1069,9 +1069,19 @@ fi
 echo ""
 echo "=== Writing version file ==="
 
+# Stamp the version the app expects, read from the single source of truth.
+# A hardcoded value here (it used to be 1.0.0) makes checkDependencies() — an
+# exact string compare against app/assets/deps-version.json — report a mismatch
+# for a freshly built tree, and the app then downloads the published bundle
+# straight over the top of it. Harmless while the local tree matched the
+# release; destructive as soon as it is ahead, which is exactly what a deps
+# upgrade branch creates.
+EXPECTED_DEPS_VERSION=$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['version'])" \
+    "$PROJECT_ROOT/app/assets/deps-version.json" 2>/dev/null || echo "0.0.0")
+
 cat > "$DEPS_DIR/version.json" << EOF
 {
-  "version": "1.0.0",
+  "version": "$EXPECTED_DEPS_VERSION",
   "installedAt": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
   "platform": "$PLATFORM_DIR",
   "architecture": "$ARCH",

--- a/Scripts/download-deps-linux.sh
+++ b/Scripts/download-deps-linux.sh
@@ -243,16 +243,44 @@ EOF
     cp "$VS_BUILT/vspipe" "$DEPS_DIR/vapoursynth/vspipe-bin"
     chmod +x "$DEPS_DIR/vapoursynth/vspipe-bin"
 
-    # Copy libraries
+    # ------------------------------------------------------------------------
+    # deps/<platform>/vapoursynth/ IS the Python package
+    # ------------------------------------------------------------------------
+    # R78 ships VapourSynth as a Python package, and vsscript resolves the
+    # Python library through a config file keyed by the ABSOLUTE PATH of
+    # libvsscript, written by `vapoursynth config` from the imported package.
+    # The copy vspipe-bin loads and the copy the module reports must therefore
+    # be the same file, or every script fails with "Python executable and
+    # library path couldn't be determined despite automatic configuration".
+    #
+    # Keeping the directory named `vapoursynth` and putting the platform dir on
+    # PYTHONPATH satisfies that without moving anything the app knows about, and
+    # leaves the plugins at <libdir>/plugins where R78 autoloads them — so no
+    # plugin path variable is set here; with both, plugins load twice.
     cp "$VS_BUILT/libvapoursynth.so"* "$DEPS_DIR/vapoursynth/"
     # vapoursynth-script was renamed vsscript in R78.
     cp "$VS_BUILT/libvsscript.so"* "$DEPS_DIR/vapoursynth/"
     # R78 split every core filter (std, resize, ...) out of libvapoursynth into
     # this module; without it the core namespaces are absent and every job fails.
     cp "$VS_BUILT/libvapoursynthfilters.so"* "$DEPS_DIR/vapoursynth/"
+    cp "$VS_BUILT/vapoursynth.abi3.so" "$DEPS_DIR/vapoursynth/"
+    # The pure-Python half of the package; without it `vapoursynth config`
+    # cannot run and vsscript's automatic configuration has nothing to call.
+    cp "$VS_BUILD_DIR/src/py/"*.py "$DEPS_DIR/vapoursynth/"
+    cp "$VS_BUILD_DIR/src/py/vapoursynth.pyi" "$DEPS_DIR/vapoursynth/" 2>/dev/null || true
+
+    # vsscript self-configures by shelling out to a `vapoursynth` executable;
+    # a from-source build creates no console script, so provide one.
+    cat > "$PYTHON_DIR/bin/vapoursynth" << 'SHIM_EOF'
+#!/bin/bash
+DEPS_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+export PYTHONHOME="$DEPS_ROOT/python"
+export PYTHONPATH="$DEPS_ROOT:$DEPS_ROOT/python-packages:${PYTHONPATH:-}"
+exec "$DEPS_ROOT/python/bin/python3" -m vapoursynth "$@"
+SHIM_EOF
+    chmod +x "$PYTHON_DIR/bin/vapoursynth"
 
     # Copy Python module
-    cp "$VS_BUILT/vapoursynth.abi3.so" "$PYTHON_PACKAGES_DIR/"
 
     # Fix RPATHs
     echo "  Fixing RPATHs..."
@@ -274,13 +302,17 @@ DEPS_ROOT="$(dirname "$SCRIPT_DIR")"
 export PATH="$DEPS_ROOT/python/bin:$PATH"
 export PYTHONHOME="$DEPS_ROOT/python"
 export VAPOURSYNTH_PLUGIN_PATH="$SCRIPT_DIR/plugins"
-export PYTHONPATH="$DEPS_ROOT/python-packages:${PYTHONPATH:-}"
+export PYTHONPATH="$DEPS_ROOT:$DEPS_ROOT/python-packages:${PYTHONPATH:-}"
 export LD_LIBRARY_PATH="$SCRIPT_DIR:$DEPS_ROOT/python/lib:$DEPS_ROOT/lib:${LD_LIBRARY_PATH:-}"
 
 # R74 removed the config-file mechanism entirely (UserPluginDir /
-# AutoloadUserPluginDir / VAPOURSYNTH_CONF_PATH no longer exist). Plugins come
-# from <libdir>/plugins plus this variable.
-export VAPOURSYNTH_EXTRA_PLUGIN_PATH="$SCRIPT_DIR/plugins"
+# AutoloadUserPluginDir / VAPOURSYNTH_CONF_PATH no longer exist). Plugins live
+# at <libdir>/plugins and are autoloaded, so no plugin variable is needed.
+#
+# vsscript resolves the Python library through a config keyed by the libvsscript
+# path, written on first use via the `vapoursynth` shim on PATH.
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$DEPS_ROOT/config}"
+mkdir -p "$XDG_CONFIG_HOME" 2>/dev/null || true
 
 exec "$SCRIPT_DIR/vspipe-bin" "$@"
 WRAPPER_EOF

--- a/Scripts/download-deps-linux.sh
+++ b/Scripts/download-deps-linux.sh
@@ -235,10 +235,15 @@ EOF
     [ -n "$VS_CC" ] && echo "  Using $VS_CC for VapourSynth"
 
     echo "  Configuring VapourSynth..."
+    # CC/CXX go through `env` rather than as assignment prefixes: bash only
+    # treats an assignment as one when it is literal at parse time, so
+    # ${VS_CC:+CC=...} would expand into a command word and fail with
+    # "CC=clang-19: command not found". Only `meson setup` needs them — the
+    # compiler is recorded in the build directory, so ninja does not.
     PATH="$PYTHON_DIR/bin:$PATH" \
-    ${VS_CC:+CC="$VS_CC"} ${VS_CXX:+CXX="$VS_CXX"} \
     PKG_CONFIG_PATH="$BUILD_DIR/pkgconfig:$BUILD_PREFIX/lib/pkgconfig" \
     LD_LIBRARY_PATH="$PYTHON_DIR/lib:$BUILD_PREFIX/lib:${LD_LIBRARY_PATH:-}" \
+    env ${VS_CC:+CC="$VS_CC"} ${VS_CXX:+CXX="$VS_CXX"} \
     # Run meson with the EMBEDDED python, not whatever meson happens to be
     # installed under. R78 locates Python with
     # `import('python').find_installation()`, which resolves to the interpreter

--- a/Scripts/download-deps-macos.sh
+++ b/Scripts/download-deps-macos.sh
@@ -1672,9 +1672,19 @@ cd "$BUILD_DIR"
 echo ""
 echo "=== Writing version file ==="
 
+# Stamp the version the app expects, read from the single source of truth.
+# A hardcoded value here (it used to be 1.0.0) makes checkDependencies() — an
+# exact string compare against app/assets/deps-version.json — report a mismatch
+# for a freshly built tree, and the app then downloads the published bundle
+# straight over the top of it. Harmless while the local tree matched the
+# release; destructive as soon as it is ahead, which is exactly what a deps
+# upgrade branch creates.
+EXPECTED_DEPS_VERSION=$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['version'])" \
+    "$PROJECT_ROOT/app/assets/deps-version.json" 2>/dev/null || echo "0.0.0")
+
 cat > "$DEPS_DIR/version.json" << EOF
 {
-  "version": "1.0.0",
+  "version": "$EXPECTED_DEPS_VERSION",
   "installedAt": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
   "platform": "$PLATFORM_DIR",
   "architecture": "$ARCH",

--- a/Scripts/download-deps-macos.sh
+++ b/Scripts/download-deps-macos.sh
@@ -312,8 +312,13 @@ path = os.environ["VS_SRC"]
 with open(path) as f:
     content = f.read()
 
-old = ("    auto res = std::to_chars(buffer, buffer + sizeof(buffer), v, std::chars_format::fixed);\n"
-       "    return std::string(buffer, res.ptr - buffer);")
+# R78 uses two call forms: vsjson.cpp passes chars_format::fixed, vspipe.cpp
+# adds a precision argument. Match either, rather than one literal string.
+m = re.search(
+    r"[ \t]*auto res = std::to_chars\(buffer, buffer \+ sizeof\(buffer\), v, std::chars_format::fixed[^)]*\);\n"
+    r"[ \t]*return std::string\(buffer, res\.ptr - buffer\);",
+    content)
+old = m.group(0) if m else None
 new = ("    // issue #39: std::to_chars(double) needs macOS 13.3+ libc++. Emit the\n"
        "    // shortest fixed-notation string that round-trips, via snprintf, so\n"
        "    // vspipe loads on Monterey 12.x.\n"
@@ -325,14 +330,14 @@ new = ("    // issue #39: std::to_chars(double) needs macOS 13.3+ libc++. Emit t
        "    std::snprintf(buffer, sizeof(buffer), \"%.17f\", v);\n"
        "    return std::string(buffer);")
 
-if old not in content:
+if old is None:
     if "issue #39" in content:
         print(f"    {path}: already patched")
         sys.exit(0)
     print(f"    ERROR: expected to_chars pattern not found in {path}", file=sys.stderr)
     sys.exit(1)
 
-content = content.replace(old, new)
+content = content.replace(old, new, 1)
 # Ensure the headers snprintf/strtod need are present (idempotent).
 content = content.replace("#include <charconv>\n",
                           "#include <charconv>\n#include <cstdio>\n#include <cstdlib>\n", 1)
@@ -788,8 +793,14 @@ STEFANOLT="https://github.com/Stefan-Olt/vs-plugin-build/releases/download/vsplu
 # plugin builds on BOTH arches (see build_plugin and the x86_64 source builds):
 # the host python has no `vapoursynth` module on a clean runner, so meson plugins
 # can't probe it the usual way and must be pointed at these explicitly.
-VS_PC_DIR="$VS_INSTALL_DIR/lib/pkgconfig"
-VS_INC_DIR="$(dirname "$(find "$VS_INSTALL_DIR/include" -name 'VapourSynth4.h' 2>/dev/null | head -1)")"
+# R78 installs VapourSynth as a Python package, so its pkgconfig and
+# include directories live under <prefix>/<site-packages>/vapoursynth/
+# rather than <prefix>/lib and <prefix>/include. Locate them instead of
+# assuming: with the wrong path every plugin resolving VapourSynth via
+# pkg-config silently fails to configure, and the bundle comes out with
+# most of its plugins missing.
+VS_PC_DIR="$(dirname "$(find "$VS_INSTALL_DIR" -name vapoursynth.pc 2>/dev/null | head -1)")"
+VS_INC_DIR="$(dirname "$(find "$VS_INSTALL_DIR" -name 'VapourSynth4.h' 2>/dev/null | head -1)")"
 
 if [ "$ARCH" = "x86_64" ]; then
     # ========================================================================

--- a/Scripts/download-deps-macos.sh
+++ b/Scripts/download-deps-macos.sh
@@ -307,7 +307,7 @@ if [ "$FORCE" = true ] || [ ! -f "$DEPS_DIR/vapoursynth/libvapoursynth.dylib" ];
         # that does.
         for vs_src in $(grep -rl "std::to_chars" src/vspipe/ 2>/dev/null); do
             VS_SRC="$vs_src" python3 - <<'PYEOF'
-import os, sys
+import os, re, sys
 path = os.environ["VS_SRC"]
 with open(path) as f:
     content = f.read()
@@ -801,6 +801,17 @@ STEFANOLT="https://github.com/Stefan-Olt/vs-plugin-build/releases/download/vsplu
 # most of its plugins missing.
 VS_PC_DIR="$(dirname "$(find "$VS_INSTALL_DIR" -name vapoursynth.pc 2>/dev/null | head -1)")"
 VS_INC_DIR="$(dirname "$(find "$VS_INSTALL_DIR" -name 'VapourSynth4.h' 2>/dev/null | head -1)")"
+# R78 installs only the API4 headers, but several plugins we build still
+# #include <VapourSynth.h> (API3) — api3 support remains in the core, just the
+# headers stopped being installed. They are still in the source tree, so top up
+# the include dir from there; without this nnedi3, addgrain, awarpsharp2, ctmf
+# and the OpenCL pair fail with "'VapourSynth.h' file not found".
+if [ -n "$VS_INC_DIR" ] && [ -d "$VS_BUILD_DIR/include" ]; then
+    for hdr in "$VS_BUILD_DIR/include/"*.h; do
+        [ -f "$hdr" ] || continue
+        [ -f "$VS_INC_DIR/$(basename "$hdr")" ] || cp "$hdr" "$VS_INC_DIR/"
+    done
+fi
 
 if [ "$ARCH" = "x86_64" ]; then
     # ========================================================================

--- a/Scripts/download-deps-macos.sh
+++ b/Scripts/download-deps-macos.sh
@@ -122,8 +122,7 @@ BREW_DEPS=(
     #   fftw       -> libfftw3f.3 + libfftw3f_threads.3 (dfttest)
     #   boost      -> libboost_filesystem + libboost_atomic (nnedi3cl)
     #   libdvdread -> libdvdread (DVD title extraction in the worker)
-    #   xz         -> liblzma.5 (linked by Stefan-Olt's x86_64 bestsource)
-    fftw boost libdvdread xz
+    fftw boost libdvdread
     # FFmpeg (build-time convenience only; at runtime both arches ship static
     # ffmpeg downloaded from evermeet.cx (x64) / martin-riedl.de (arm64))
     ffmpeg
@@ -154,7 +153,7 @@ done
 # On the only available Intel runner (macos-15-intel) `brew install` pours
 # minos 14/15 bottles that won't load on macOS 12. Build the few libraries we
 # *bundle* from source so they inherit MACOSX_DEPLOYMENT_TARGET (12.0):
-#   zimg/fftw/libdvdread/xz  - stable C ABIs; dropped in over the Homebrew
+#   zimg/fftw/libdvdread     - stable C ABIs; dropped in over the Homebrew
 #                              copies just before the repoint pass.
 #   boost (filesystem,atomic) - ABI-sensitive, so the OpenCL plugins
 #                              (nnedi3cl/knlmeanscl) are ALSO compiled against
@@ -167,14 +166,6 @@ if [ "$ARCH" = "x86_64" ]; then
     NPROC=$(sysctl -n hw.ncpu)
     SRC_TMP="$BUILD_DIR/srclib-src"
     mkdir -p "$SRCLIB" "$SRC_TMP"
-    cd "$SRC_TMP"
-
-    # xz / liblzma 5.4.6 (pre-5.6 to avoid the 5.6.x backdoor) -> liblzma.5.dylib
-    echo "  Building xz (liblzma 5.4.6)..."
-    curl -fsSL "https://github.com/tukaani-project/xz/releases/download/v5.4.6/xz-5.4.6.tar.gz" -o xz.tar.gz
-    tar xzf xz.tar.gz && cd xz-5.4.6
-    ./configure --prefix="$SRCLIB" --enable-shared --disable-static --disable-doc -q
-    make -j"$NPROC" >/dev/null && make install >/dev/null
     cd "$SRC_TMP"
 
     # fftw 3.3.10, single precision + threads -> libfftw3f.3 + libfftw3f_threads.3
@@ -216,7 +207,7 @@ if [ "$ARCH" = "x86_64" ]; then
 
     # boost is linked by the OpenCL plugins built later; give it an @rpath id so
     # those plugins record a *repointable* reference (the repoint pass skips refs
-    # that are already @loader_path/...). zimg/fftw/dvdread/lzma get their ids
+    # that are already @loader_path/...). zimg/fftw/dvdread get their ids
     # normalized when they're dropped into the bundle.
     for b in libboost_filesystem libboost_atomic; do
         [ -f "$SRCLIB/lib/$b.dylib" ] && install_name_tool -id "@rpath/$b.dylib" "$SRCLIB/lib/$b.dylib"
@@ -780,20 +771,6 @@ if [ "$ARCH" = "x86_64" ]; then
     download_prebuilt_plugin "CTMF"          "libctmf.dylib"        "$STEFANOLT/com.holywu.ctmf/r5/darwin-x86_64/2024-09-30T20.54.04%2B00.00Z/CTMF-r5-darwin-x86_64.zip"
     download_prebuilt_plugin "TCanny"        "libtcanny.dylib"      "$STEFANOLT/com.holywu.tcanny/r14/darwin-x86_64/2024-09-30T21.00.45%2B00.00Z/TCanny-r14-darwin-x86_64.zip"
     download_prebuilt_plugin "TemporalMedian" "libtmedian.dylib"    "$STEFANOLT/com.nodame.temporalmedian/v1/darwin-x86_64/2024-09-30T21.01.26%2B00.00Z/TemporalMedian-v1-darwin-x86_64.zip"
-    download_prebuilt_plugin "BestSource"    "libbestsource.dylib"  "$STEFANOLT/com.vapoursynth.bestsource/R16/darwin-x86_64/2026-01-10T19.07.30%2B00.00Z/BestSource-R16-darwin-x86_64.zip"
-
-    # Stefan-Olt's x86_64 BestSource dynamically links liblzma; bundle it from
-    # Homebrew (xz) and repoint the reference at the bundled copy in lib/.
-    if [ -f "$PLUGINS_DIR/libbestsource.dylib" ]; then
-        if [ ! -f "$LIB_DIR/liblzma.5.dylib" ] && [ -f "$BREW_PREFIX/opt/xz/lib/liblzma.5.dylib" ]; then
-            cp "$BREW_PREFIX/opt/xz/lib/liblzma.5.dylib" "$LIB_DIR/liblzma.5.dylib"
-            install_name_tool -id "@loader_path/liblzma.5.dylib" "$LIB_DIR/liblzma.5.dylib" 2>/dev/null || true
-            codesign -s - -f "$LIB_DIR/liblzma.5.dylib" 2>/dev/null || true
-        fi
-        install_name_tool -change "$BREW_PREFIX/opt/xz/lib/liblzma.5.dylib" \
-            "@loader_path/../../lib/liblzma.5.dylib" "$PLUGINS_DIR/libbestsource.dylib" 2>/dev/null || true
-        codesign -s - -f "$PLUGINS_DIR/libbestsource.dylib" 2>/dev/null || true
-    fi
 
     # ---- The four plugins Stefan-Olt does not ship: build from source ----
     cd "$BUILD_DIR"
@@ -1260,28 +1237,6 @@ else
 fi
 download_prebuilt_plugin "TemporalMedian" "libtmedian.dylib" "$TMEDIAN_URL"
 
-# BestSource (core.bs - source loader, bundled for parity)
-if [ "$ARCH" = "arm64" ]; then
-    BESTSOURCE_URL="$STEFANOLT/com.vapoursynth.bestsource/R16/darwin-aarch64/2026-01-10T18.55.40%2B00.00Z/BestSource-R16-darwin-aarch64.zip"
-else
-    BESTSOURCE_URL="$STEFANOLT/com.vapoursynth.bestsource/R16/darwin-x86_64/2026-01-10T19.07.30%2B00.00Z/BestSource-R16-darwin-x86_64.zip"
-fi
-download_prebuilt_plugin "BestSource" "libbestsource.dylib" "$BESTSOURCE_URL"
-
-# Stefan-Olt's aarch64 BestSource links the *system* /usr/lib/liblzma.5.dylib
-# (the x86_64 build links Homebrew's xz copy, handled in the x86_64 branch above).
-# Bundle liblzma from Homebrew (xz) and repoint the reference at the bundled copy
-# so the issue #28 guard stays strict and we don't depend on the system lib.
-if [ "$ARCH" = "arm64" ] && [ -f "$PLUGINS_DIR/libbestsource.dylib" ]; then
-    if [ ! -f "$LIB_DIR/liblzma.5.dylib" ] && [ -f "$BREW_PREFIX/opt/xz/lib/liblzma.5.dylib" ]; then
-        cp "$BREW_PREFIX/opt/xz/lib/liblzma.5.dylib" "$LIB_DIR/liblzma.5.dylib"
-        install_name_tool -id "@loader_path/liblzma.5.dylib" "$LIB_DIR/liblzma.5.dylib" 2>/dev/null || true
-        codesign -s - -f "$LIB_DIR/liblzma.5.dylib" 2>/dev/null || true
-    fi
-    install_name_tool -change "/usr/lib/liblzma.5.dylib" \
-        "@loader_path/../../lib/liblzma.5.dylib" "$PLUGINS_DIR/libbestsource.dylib" 2>/dev/null || true
-    codesign -s - -f "$PLUGINS_DIR/libbestsource.dylib" 2>/dev/null || true
-fi
 fi  # end plugin arch split (x86_64 pre-built / arm64 from-source)
 
 # zsmooth (core.zsmooth.CCD - chroma denoiser; also Cnr4 and a set of
@@ -1555,7 +1510,7 @@ if [ "$ARCH" = "x86_64" ] && [ -d "$SRCLIB/lib" ]; then
     # The remaining libs live in lib/; the repoint passes below normalize their
     # ids and inter-references. cp -f follows the versioned symlinks.
     for libname in libfftw3f.3.dylib libfftw3f_threads.3.dylib libdvdread.dylib \
-                   liblzma.5.dylib libboost_filesystem.dylib libboost_atomic.dylib; do
+                   libboost_filesystem.dylib libboost_atomic.dylib; do
         if [ -f "$SRCLIB/lib/$libname" ]; then
             cp -f "$SRCLIB/lib/$libname" "$LIB_DIR/$libname"
             codesign -s - -f "$LIB_DIR/$libname" 2>/dev/null || true
@@ -1578,7 +1533,7 @@ fi
 # the bundle is fully relocatable.
 echo ""
 echo "=== Repointing plugin support-lib references to bundled lib/ ==="
-SUPPORT_LIBS=(libfftw3f.3.dylib libfftw3f_threads.3.dylib libboost_filesystem.dylib libboost_atomic.dylib liblzma.5.dylib libdvdread.dylib)
+SUPPORT_LIBS=(libfftw3f.3.dylib libfftw3f_threads.3.dylib libboost_filesystem.dylib libboost_atomic.dylib libdvdread.dylib)
 for plugin in "$PLUGINS_DIR"/*.dylib; do
     [ -f "$plugin" ] || continue
     plugin_base=$(basename "$plugin")
@@ -1817,7 +1772,7 @@ else
     echo "The MACOSX_DEPLOYMENT_TARGET export fixes everything built from source here."
     echo "Anything still flagged is a *prebuilt* artifact this script only copies, so"
     echo "it needs its own fix:"
-    echo "  - Homebrew bottles (zimg/fftw/boost/libdvdread/xz): the macos-15 runner"
+    echo "  - Homebrew bottles (zimg/fftw/boost/libdvdread): the macos-15 runner"
     echo "    installs Sequoia bottles. Build these from source with the target set,"
     echo "    or fetch older-OS bottles."
     echo "  - ffmpeg (evermeet.cx / martin-riedl.de) and Python (python-build-standalone):"

--- a/Scripts/download-deps-macos.sh
+++ b/Scripts/download-deps-macos.sh
@@ -270,16 +270,32 @@ PYTHON_INCLUDE="$PYTHON_DIR/include/python${PYTHON_MAJOR_MINOR}"
 echo ""
 echo "=== Building VapourSynth from source ==="
 
+VS_TAG="R78"
 VS_BUILD_DIR="$BUILD_DIR/vapoursynth"
 VS_INSTALL_DIR="$BUILD_DIR/vapoursynth-install"
 
 if [ "$FORCE" = true ] || [ ! -f "$DEPS_DIR/vapoursynth/libvapoursynth.dylib" ]; then
-    echo "  Cloning VapourSynth R73..."
+    echo "  Cloning VapourSynth $VS_TAG..."
     rm -rf "$VS_BUILD_DIR"
-    git clone --depth 1 --branch R73 https://github.com/vapoursynth/vapoursynth.git "$VS_BUILD_DIR" 2>/dev/null || \
+    git clone --depth 1 --branch "$VS_TAG" https://github.com/vapoursynth/vapoursynth.git "$VS_BUILD_DIR" 2>/dev/null || \
     git clone --depth 1 https://github.com/vapoursynth/vapoursynth.git "$VS_BUILD_DIR"
 
     cd "$VS_BUILD_DIR"
+
+    # ------------------------------------------------------------------------
+    # zimg API guard (backport of upstream 37eed3dd)
+    # ------------------------------------------------------------------------
+    # R78 reads zimg's chromatic_adaptation field unconditionally, but that
+    # field only exists in a zimg newer than the current release (3.0.6), so
+    # R78 does not compile against any released zimg. Upstream fixed it two
+    # days after tagging; this is that fix. Hard-fail rather than fall over in
+    # the compiler with a confusing error.
+    git apply "$SCRIPT_DIR/patches/vapoursynth-r78-zimg-api-guard.patch" || {
+        echo "  ERROR: patches/vapoursynth-r78-zimg-api-guard.patch did not apply." >&2
+        echo "  If VapourSynth has moved past R78 the fix is already upstream — drop it." >&2
+        exit 1
+    }
+    echo "  Applied the zimg chromatic_adaptation API guard"
 
     # ------------------------------------------------------------------------
     # Back-deploy patch for Monterey (issue #39) — x64 only
@@ -371,34 +387,43 @@ EOF
     meson setup build \
         --prefix="$VS_INSTALL_DIR" \
         --buildtype=release \
-        -Dlibdir=lib \
-        -Dplugindir="" \
-        -Dpython3_bin="$PYTHON_BIN"
+        -Dlibdir=lib
 
     echo "  Building VapourSynth..."
     PATH="$PYTHON_DIR/bin:$PATH" ninja -C build
     PATH="$PYTHON_DIR/bin:$PATH" ninja -C build install
 
     echo "  Copying VapourSynth files..."
-    # Copy vspipe
-    cp "$VS_INSTALL_DIR/bin/vspipe" "$DEPS_DIR/vapoursynth/vspipe-bin"
+    # Copy from the build directory, not the install prefix. R74 turned
+    # VapourSynth into a Python package ("pip install vapoursynth"), so
+    # `ninja install` now puts vspipe and every library under
+    # <prefix>/<python-site-packages>/vapoursynth/ rather than <prefix>/bin and
+    # <prefix>/lib. The build directory is flat and does not depend on which
+    # Python did the install, so it is the stable place to copy from.
+    VS_BUILT="$VS_BUILD_DIR/build"
+
+    cp "$VS_BUILT/vspipe" "$DEPS_DIR/vapoursynth/vspipe-bin"
     chmod +x "$DEPS_DIR/vapoursynth/vspipe-bin"
 
     # Copy libraries with both names for compatibility
-    cp "$VS_INSTALL_DIR/lib/libvapoursynth.4.dylib" "$DEPS_DIR/vapoursynth/libvapoursynth.dylib"
-    cp "$VS_INSTALL_DIR/lib/libvapoursynth.4.dylib" "$DEPS_DIR/vapoursynth/libvapoursynth.4.dylib"
-    cp "$VS_INSTALL_DIR/lib/libvapoursynth-script.4.dylib" "$DEPS_DIR/vapoursynth/libvapoursynth-script.dylib"
-    cp "$VS_INSTALL_DIR/lib/libvapoursynth-script.4.dylib" "$DEPS_DIR/vapoursynth/libvapoursynth-script.4.dylib"
+    cp "$VS_BUILT/libvapoursynth.4.dylib" "$DEPS_DIR/vapoursynth/libvapoursynth.dylib"
+    cp "$VS_BUILT/libvapoursynth.4.dylib" "$DEPS_DIR/vapoursynth/libvapoursynth.4.dylib"
+    # vapoursynth-script was renamed vsscript in R78, and is unversioned.
+    cp "$VS_BUILT/libvsscript.dylib" "$DEPS_DIR/vapoursynth/libvsscript.dylib"
+    # R78 split every core filter (std, resize, ...) out of libvapoursynth into
+    # this module. Without it the core namespaces are simply absent and every
+    # job fails at script evaluation.
+    cp "$VS_BUILT/libvapoursynthfilters.dylib" "$DEPS_DIR/vapoursynth/libvapoursynthfilters.dylib"
 
     # Copy zimg from Homebrew (will fix paths to be relative)
     cp "$BREW_PREFIX/lib/libzimg.2.dylib" "$DEPS_DIR/vapoursynth/libzimg.dylib"
 
     # Copy Python module
-    find "$VS_BUILD_DIR/build" -name "vapoursynth*.so" -exec cp {} "$PYTHON_PACKAGES_DIR/" \;
+    cp "$VS_BUILT/vapoursynth.abi3.so" "$PYTHON_PACKAGES_DIR/"
 
     # Fix Python module library paths (critical for self-contained operation)
     cd "$PYTHON_PACKAGES_DIR"
-    for so_file in vapoursynth.cpython-*.so; do
+    for so_file in vapoursynth*.so; do
         if [ -f "$so_file" ]; then
             # Fix libvapoursynth reference to use loader_path
             install_name_tool -change "@rpath/libvapoursynth.4.dylib" \
@@ -459,28 +484,15 @@ export PYTHONPATH="$DEPS_ROOT/python-packages:${PYTHONPATH:-}"
 # Add our lib directories to dylib search path
 export DYLD_LIBRARY_PATH="$SCRIPT_DIR:$DEPS_ROOT/python/lib:${DYLD_LIBRARY_PATH:-}"
 
-# Generate config dynamically with correct absolute path
-CONF_FILE=$(mktemp)
-cat > "$CONF_FILE" << EOF
-UserPluginDir=$SCRIPT_DIR/plugins
-AutoloadUserPluginDir=true
-AutoloadSystemPluginDir=false
-EOF
-export VAPOURSYNTH_CONF_PATH="$CONF_FILE"
+# R74 removed the config-file mechanism entirely (UserPluginDir /
+# AutoloadUserPluginDir / VAPOURSYNTH_CONF_PATH no longer exist). Plugins now
+# come from <libdir>/plugins plus this variable, which is simpler than the temp
+# config file this wrapper used to generate.
+export VAPOURSYNTH_EXTRA_PLUGIN_PATH="$SCRIPT_DIR/plugins"
 
-# Run vspipe and clean up config
-"$SCRIPT_DIR/vspipe-bin" "$@"
-EXIT_CODE=$?
-rm -f "$CONF_FILE"
-exit $EXIT_CODE
+exec "$SCRIPT_DIR/vspipe-bin" "$@"
 WRAPPER_EOF
     chmod +x "$DEPS_DIR/vapoursynth/vspipe"
-
-    # Create fallback config file (used if wrapper doesn't generate one)
-    cat > "$DEPS_DIR/vapoursynth/vapoursynth.conf" << 'CONF_EOF'
-AutoloadUserPluginDir=false
-AutoloadSystemPluginDir=false
-CONF_EOF
 
     cd "$BUILD_DIR"
     echo "  Built VapourSynth from source with embedded Python"
@@ -1646,7 +1658,7 @@ done
 
 # Sign Python module
 cd "$PYTHON_PACKAGES_DIR"
-for so_file in vapoursynth.cpython-*.so; do
+for so_file in vapoursynth*.so; do
     if [ -f "$so_file" ]; then
         codesign -s - -f "$so_file" 2>/dev/null && echo "  Signed $so_file"
     fi

--- a/Scripts/download-deps-macos.sh
+++ b/Scripts/download-deps-macos.sh
@@ -801,6 +801,21 @@ STEFANOLT="https://github.com/Stefan-Olt/vs-plugin-build/releases/download/vsplu
 # most of its plugins missing.
 VS_PC_DIR="$(dirname "$(find "$VS_INSTALL_DIR" -name vapoursynth.pc 2>/dev/null | head -1)")"
 VS_INC_DIR="$(dirname "$(find "$VS_INSTALL_DIR" -name 'VapourSynth4.h' 2>/dev/null | head -1)")"
+# R78's generated vapoursynth.pc dropped the libdir variable that R73's had.
+# Plugins whose meson.build does
+#   vapoursynth_dep.get_variable(pkgconfig: 'libdir')
+# to decide where to install (addgrain, tcanny) then fail configuration with
+# "Could not get pkg-config variable and no default provided". The value is only
+# used as an install prefix and we copy the built dylib ourselves, so any sane
+# path restores the lookup.
+if [ -n "$VS_PC_DIR" ] && [ -f "$VS_PC_DIR/vapoursynth.pc" ] \
+   && ! grep -q '^libdir=' "$VS_PC_DIR/vapoursynth.pc"; then
+    awk '{print} /^includedir=/ && !done {print "libdir=${prefix}/lib"; done=1}' \
+        "$VS_PC_DIR/vapoursynth.pc" > "$VS_PC_DIR/vapoursynth.pc.tmp" \
+        && mv "$VS_PC_DIR/vapoursynth.pc.tmp" "$VS_PC_DIR/vapoursynth.pc"
+    echo "  Added libdir to vapoursynth.pc (R78 omits it)"
+fi
+
 # R78 installs only the API4 headers, but several plugins we build still
 # #include <VapourSynth.h> (API3) — api3 support remains in the core, just the
 # headers stopped being installed. They are still in the source tree, so top up

--- a/Scripts/download-deps-macos.sh
+++ b/Scripts/download-deps-macos.sh
@@ -384,6 +384,21 @@ EOF
     # Configure with no system plugin path and using our embedded Python
     PATH="$PYTHON_DIR/bin:$BREW_PREFIX/opt/cython/bin:$PATH" \
     PKG_CONFIG_PATH="$BUILD_DIR/pkgconfig:$BREW_PREFIX/lib/pkgconfig" \
+    # meson looks for a "cython3" program before "cython", so apt's cython3
+    # (0.29 on jammy) wins over the Cython 3.x we just installed into the
+    # embedded interpreter no matter how PATH is ordered — and R78's
+    # vapoursynth.pyx uses Cython 3 syntax, failing with "Syntax error in C
+    # variable declaration" on `noexcept`. Provide both names as wrappers that
+    # run the module, which also sidesteps the console script's baked-in
+    # shebang (it points at the machine that built the interpreter).
+    for cy in cython cython3; do
+        cat > "$PYTHON_DIR/bin/$cy" << CYEOF
+#!/bin/bash
+exec "$PYTHON_DIR/bin/python3" -m cython "\$@"
+CYEOF
+        chmod +x "$PYTHON_DIR/bin/$cy"
+    done
+
     # Run meson with the EMBEDDED python, not whatever meson happens to be
     # installed under. R78 locates Python with
     # `import('python').find_installation()`, which resolves to the interpreter

--- a/Scripts/download-deps-macos.sh
+++ b/Scripts/download-deps-macos.sh
@@ -396,21 +396,52 @@ EOF
     cp "$VS_BUILT/vspipe" "$DEPS_DIR/vapoursynth/vspipe-bin"
     chmod +x "$DEPS_DIR/vapoursynth/vspipe-bin"
 
-    # Copy libraries with both names for compatibility
-    cp "$VS_BUILT/libvapoursynth.4.dylib" "$DEPS_DIR/vapoursynth/libvapoursynth.dylib"
-    cp "$VS_BUILT/libvapoursynth.4.dylib" "$DEPS_DIR/vapoursynth/libvapoursynth.4.dylib"
+    # ------------------------------------------------------------------------
+    # deps/<platform>/vapoursynth/ IS the Python package
+    # ------------------------------------------------------------------------
+    # R78 ships VapourSynth as a Python package, and vsscript resolves the
+    # Python library through a config file keyed by the ABSOLUTE PATH of
+    # libvsscript. That config is written by `vapoursynth config`, which records
+    # the libvsscript belonging to the imported package. So the copy vspipe-bin
+    # loads and the copy the module reports have to be the same file, or every
+    # script fails with "Python executable and library path couldn't be
+    # determined despite automatic configuration".
+    #
+    # Keeping the directory name `vapoursynth` and putting the platform dir on
+    # PYTHONPATH satisfies that without moving anything the app already knows
+    # about. It also puts the plugins at <libdir>/plugins, which R78 autoloads,
+    # so VAPOURSYNTH_EXTRA_PLUGIN_PATH is no longer set on this platform — with
+    # both, every plugin loads twice and warns about it.
+    cp "$VS_BUILT/libvapoursynth.4.dylib"      "$DEPS_DIR/vapoursynth/libvapoursynth.4.dylib"
+    ln -sf libvapoursynth.4.dylib              "$DEPS_DIR/vapoursynth/libvapoursynth.dylib"
     # vapoursynth-script was renamed vsscript in R78, and is unversioned.
-    cp "$VS_BUILT/libvsscript.dylib" "$DEPS_DIR/vapoursynth/libvsscript.dylib"
+    cp "$VS_BUILT/libvsscript.dylib"           "$DEPS_DIR/vapoursynth/libvsscript.dylib"
     # R78 split every core filter (std, resize, ...) out of libvapoursynth into
     # this module. Without it the core namespaces are simply absent and every
     # job fails at script evaluation.
     cp "$VS_BUILT/libvapoursynthfilters.dylib" "$DEPS_DIR/vapoursynth/libvapoursynthfilters.dylib"
+    cp "$VS_BUILT/vapoursynth.abi3.so"         "$DEPS_DIR/vapoursynth/"
+    # The pure-Python half of the package. Without it `vapoursynth config`
+    # cannot run and vsscript's automatic configuration has nothing to call.
+    cp "$VS_BUILD_DIR/src/py/"*.py "$VS_BUILD_DIR/src/py/vapoursynth.pyi" \
+        "$DEPS_DIR/vapoursynth/" 2>/dev/null || \
+        cp "$VS_BUILD_DIR/src/py/"*.py "$DEPS_DIR/vapoursynth/"
+
+    # vsscript self-configures by shelling out to a `vapoursynth` executable.
+    # A from-source build creates no console script, so provide one.
+    cat > "$PYTHON_DIR/bin/vapoursynth" << 'SHIM_EOF'
+#!/bin/bash
+DEPS_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+export PYTHONHOME="$DEPS_ROOT/python"
+export PYTHONPATH="$DEPS_ROOT:$DEPS_ROOT/python-packages:${PYTHONPATH:-}"
+exec "$DEPS_ROOT/python/bin/python3" -m vapoursynth "$@"
+SHIM_EOF
+    chmod +x "$PYTHON_DIR/bin/vapoursynth"
 
     # Copy zimg from Homebrew (will fix paths to be relative)
     cp "$BREW_PREFIX/lib/libzimg.2.dylib" "$DEPS_DIR/vapoursynth/libzimg.dylib"
 
     # Copy Python module
-    cp "$VS_BUILT/vapoursynth.abi3.so" "$PYTHON_PACKAGES_DIR/"
 
     # Fix Python module library paths (critical for self-contained operation)
     cd "$PYTHON_PACKAGES_DIR"
@@ -470,16 +501,20 @@ export PYTHONHOME="$DEPS_ROOT/python"
 export VAPOURSYNTH_PLUGIN_PATH="$SCRIPT_DIR/plugins"
 
 # Set Python path to load our vapoursynth module and packages
-export PYTHONPATH="$DEPS_ROOT/python-packages:${PYTHONPATH:-}"
+export PYTHONPATH="$DEPS_ROOT:$DEPS_ROOT/python-packages:${PYTHONPATH:-}"
 
 # Add our lib directories to dylib search path
 export DYLD_LIBRARY_PATH="$SCRIPT_DIR:$DEPS_ROOT/python/lib:${DYLD_LIBRARY_PATH:-}"
 
 # R74 removed the config-file mechanism entirely (UserPluginDir /
-# AutoloadUserPluginDir / VAPOURSYNTH_CONF_PATH no longer exist). Plugins now
-# come from <libdir>/plugins plus this variable, which is simpler than the temp
-# config file this wrapper used to generate.
-export VAPOURSYNTH_EXTRA_PLUGIN_PATH="$SCRIPT_DIR/plugins"
+# AutoloadUserPluginDir / VAPOURSYNTH_CONF_PATH no longer exist). Plugins live
+# at <libdir>/plugins and are autoloaded, so no plugin variable is needed here.
+#
+# vsscript resolves the Python library through a config keyed by the libvsscript
+# path and writes it on first use via the `vapoursynth` shim on PATH, so give it
+# somewhere writable to put it.
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$DEPS_ROOT/config}"
+mkdir -p "$XDG_CONFIG_HOME" 2>/dev/null || true
 
 exec "$SCRIPT_DIR/vspipe-bin" "$@"
 WRAPPER_EOF

--- a/Scripts/download-deps-macos.sh
+++ b/Scripts/download-deps-macos.sh
@@ -301,7 +301,11 @@ if [ "$FORCE" = true ] || [ ! -f "$DEPS_DIR/vapoursynth/libvapoursynth.dylib" ];
     # bundle stays byte-for-byte unchanged.
     if [ "$ARCH" = "x86_64" ]; then
         echo "  Patching vspipe doubleToString for Monterey back-deploy (issue #39)..."
-        for vs_src in src/vspipe/vsjson.cpp src/vspipe/vspipe.cpp; do
+        # R73 carried doubleToString() in both files; R78 has it only in
+        # vsjson.cpp. Patch whichever files actually contain it, so this neither
+        # hard-fails on a file that no longer needs it nor silently skips one
+        # that does.
+        for vs_src in $(grep -rl "std::to_chars" src/vspipe/ 2>/dev/null); do
             VS_SRC="$vs_src" python3 - <<'PYEOF'
 import os, sys
 path = os.environ["VS_SRC"]
@@ -341,7 +345,7 @@ PYEOF
 
     # Install Cython in our embedded Python for building
     echo "  Installing Cython in embedded Python..."
-    "$PYTHON_BIN" -m pip install --quiet cython
+    "$PYTHON_BIN" -m pip install --quiet cython meson
 
     # Create pkg-config file for our embedded Python
     mkdir -p "$BUILD_DIR/pkgconfig"
@@ -375,7 +379,16 @@ EOF
     # Configure with no system plugin path and using our embedded Python
     PATH="$PYTHON_DIR/bin:$BREW_PREFIX/opt/cython/bin:$PATH" \
     PKG_CONFIG_PATH="$BUILD_DIR/pkgconfig:$BREW_PREFIX/lib/pkgconfig" \
-    meson setup build \
+    # Run meson with the EMBEDDED python, not whatever meson happens to be
+    # installed under. R78 locates Python with
+    # `import('python').find_installation()`, which resolves to the interpreter
+    # meson itself is running as — PATH does not influence it, and the
+    # -Dpython3_bin option that used to override it was removed. Left alone,
+    # meson picks the runner's system python: on Linux that has no development
+    # headers, so configuration dies with "Header 'Python.h' could not be
+    # found", and on macOS it silently builds and installs against Homebrew's
+    # python instead of the one we ship.
+    "$PYTHON_BIN" -m mesonbuild.mesonmain setup build \
         --prefix="$VS_INSTALL_DIR" \
         --buildtype=release \
         -Dlibdir=lib
@@ -441,21 +454,6 @@ SHIM_EOF
     # Copy zimg from Homebrew (will fix paths to be relative)
     cp "$BREW_PREFIX/lib/libzimg.2.dylib" "$DEPS_DIR/vapoursynth/libzimg.dylib"
 
-    # Copy Python module
-
-    # Fix Python module library paths (critical for self-contained operation)
-    cd "$PYTHON_PACKAGES_DIR"
-    for so_file in vapoursynth*.so; do
-        if [ -f "$so_file" ]; then
-            # Fix libvapoursynth reference to use loader_path
-            install_name_tool -change "@rpath/libvapoursynth.4.dylib" \
-                "@loader_path/../vapoursynth/libvapoursynth.4.dylib" "$so_file" 2>/dev/null || true
-            # Fix Python library reference (from python-build-standalone's internal path)
-            install_name_tool -change "/install/lib/libpython${PYTHON_MAJOR_MINOR}.dylib" \
-                "@loader_path/../python/lib/libpython${PYTHON_MAJOR_MINOR}.dylib" "$so_file" 2>/dev/null || true
-        fi
-    done
-
     echo "  Fixing library paths..."
     cd "$DEPS_DIR/vapoursynth"
 
@@ -464,21 +462,35 @@ SHIM_EOF
         install_name_tool -id "@loader_path/$lib" "$lib" 2>/dev/null || true
     done
 
-    # Fix vspipe-bin to use relative paths
-    install_name_tool -change "$VS_INSTALL_DIR/lib/libvapoursynth-script.4.dylib" \
-        "@executable_path/libvapoursynth-script.4.dylib" vspipe-bin
-
-    # Fix libvapoursynth-script references
-    install_name_tool -change "$VS_INSTALL_DIR/lib/libvapoursynth.4.dylib" \
-        "@loader_path/libvapoursynth.4.dylib" libvapoursynth-script.dylib
-    install_name_tool -change "$VS_INSTALL_DIR/lib/libvapoursynth.4.dylib" \
-        "@loader_path/libvapoursynth.4.dylib" libvapoursynth-script.4.dylib
-
-    # Fix Python library reference to use our embedded Python
-    install_name_tool -change "$PYTHON_DIR/lib/libpython${PYTHON_MAJOR_MINOR}.dylib" \
-        "@executable_path/../python/lib/libpython${PYTHON_MAJOR_MINOR}.dylib" libvapoursynth-script.dylib
-    install_name_tool -change "$PYTHON_DIR/lib/libpython${PYTHON_MAJOR_MINOR}.dylib" \
-        "@executable_path/../python/lib/libpython${PYTHON_MAJOR_MINOR}.dylib" libvapoursynth-script.4.dylib
+    # Everything that links libvapoursynth or libpython now sits in this one
+    # directory (R78 ships them as a Python package), so fix them in one pass.
+    #
+    # The python reference is "/install/lib/libpython3.X.dylib" —
+    # python-build-standalone bakes that absolute path in as the install name,
+    # and it does not exist on any machine. Rewriting it is what makes the
+    # bundle self-contained; miss it and vspipe dies at load with
+    # "Library not loaded: /install/lib/libpython3.12.dylib". Both that and the
+    # build-tree path are rewritten, so it does not matter which the linker
+    # recorded.
+    for macho in libvsscript.dylib libvapoursynthfilters.dylib vapoursynth.abi3.so \
+                 vspipe-bin libvapoursynth-script.dylib libvapoursynth-script.4.dylib; do
+        [ -e "$macho" ] || continue
+        for vs_ref in "$VS_INSTALL_DIR/lib/libvapoursynth.4.dylib" "@rpath/libvapoursynth.4.dylib"; do
+            install_name_tool -change "$vs_ref" \
+                "@loader_path/libvapoursynth.4.dylib" "$macho" 2>/dev/null || true
+        done
+        # vspipe links vsscript through @rpath. That happens to resolve via the
+        # DYLD_LIBRARY_PATH the wrapper and the worker both set, so it "works"
+        # without this — but only because of the environment, which makes the
+        # binary non-relocatable and the failure environment-dependent.
+        install_name_tool -change "@rpath/libvsscript.dylib" \
+            "@loader_path/libvsscript.dylib" "$macho" 2>/dev/null || true
+        for py_ref in "/install/lib/libpython${PYTHON_MAJOR_MINOR}.dylib" \
+                      "$PYTHON_DIR/lib/libpython${PYTHON_MAJOR_MINOR}.dylib"; do
+            install_name_tool -change "$py_ref" \
+                "@loader_path/../python/lib/libpython${PYTHON_MAJOR_MINOR}.dylib" "$macho" 2>/dev/null || true
+        done
+    done
 
     # Fix zimg references
     install_name_tool -change "$BREW_PREFIX/opt/zimg/lib/libzimg.2.dylib" \

--- a/Scripts/download-deps-windows.ps1
+++ b/Scripts/download-deps-windows.ps1
@@ -4,8 +4,8 @@
 
 .DESCRIPTION
     This script downloads and sets up:
-    - VapourSynth R73 (portable, includes Python 3.8)
-    - Python 3.8 embeddable (for VSScript)
+    - VapourSynth R78 (installed as a Python wheel)
+    - Python 3.12 embeddable (hosts the wheel and VSScript)
     - FFmpeg (latest GPL build)
     - VapourSynth plugins (mvtools, nnedi3cl, znedi3, eedi3m, fmtconv, miscfilters, dfttest, neo_f3kdb, cas, fft3dfilter, descratch, temporalmedian)
     - FFTW library (required by dfttest)
@@ -57,6 +57,13 @@ if (-not (Test-Path $TempDir)) {
     New-Item -ItemType Directory -Force -Path $TempDir | Out-Null
 }
 
+# VapourSynth release and the embeddable Python it is installed into.
+# The wheel is cp312-abi3, so any Python >= 3.12 works; keep this in step
+# with the macOS and Linux bundles.
+$VSRelease = "R78"
+$PythonVersion = "3.12.10"
+$PythonTag = "312"
+
 function Download-File {
     param([string]$Url, [string]$OutFile)
     Write-Host "  Downloading: $Url" -ForegroundColor Gray
@@ -64,106 +71,69 @@ function Download-File {
 }
 
 # =============================================================================
-# 1. VapourSynth R73 Portable
+# 1. Python 3.12 embeddable + VapourSynth R78 wheel
 # =============================================================================
+# R74 turned VapourSynth into a Python package and R78 ships Windows purely as
+# a wheel: VapourSynth64-Portable-R78.zip contains only wheel\, vspipe.bat,
+# pip.bat and docs - no VSPipe.exe, no DLLs, no Python. The wheel itself is
+# self-contained (vspipe.exe, libvapoursynth.dll, libvapoursynthfilters*.dll,
+# vsscript.dll, vapoursynth.pyd), so the R73 flow - portable zip first, then
+# bolt Python 3.8 on the side - no longer applies.
+#
+# This mirrors the official Install-Portable-VapourSynth-R78.ps1: unpack an
+# embeddable Python, add Lib\site-packages to its ._pth, then install the
+# wheel. We expand the wheel rather than bootstrapping pip into the embeddable
+# interpreter; a wheel is a zip, this one has no .data payload and no scripts,
+# and expanding keeps the build deterministic and offline-friendly.
+#
+# Python 3.12 is the floor R74 set (the wheel is cp312-abi3, so 3.12+ all work)
+# and matches the macOS and Linux bundles. Pinned rather than probing for the
+# newest patch, so the bundle is reproducible.
 Write-Host ""
-Write-Host "[1/8] Downloading VapourSynth R73 Portable..." -ForegroundColor Yellow
+Write-Host "[1/8] Installing Python $PythonVersion embeddable + VapourSynth $VSRelease..." -ForegroundColor Yellow
 
-$VSZip = Join-Path $TempDir "vapoursynth.zip"
-$VSUrl = "https://github.com/vapoursynth/vapoursynth/releases/download/R73/VapourSynth64-Portable-R73.zip"
-
-if (-not (Test-Path "$FullTargetDir\vapoursynth\VSPipe.exe")) {
-    Download-File -Url $VSUrl -OutFile $VSZip
-    Expand-Archive -Path $VSZip -DestinationPath "$FullTargetDir\vapoursynth" -Force
-    Remove-Item $VSZip -Force
-    Write-Host "  VapourSynth R73 installed" -ForegroundColor Green
-} else {
-    Write-Host "  VapourSynth R73 already installed" -ForegroundColor Gray
-}
-
-# =============================================================================
-# 2. Python 3.8 Embeddable (for VSScriptPython38.dll)
-# =============================================================================
-Write-Host ""
-Write-Host "[2/8] Downloading Python 3.8.10 embeddable..." -ForegroundColor Yellow
-
-$PythonZip = Join-Path $TempDir "python38.zip"
-$PythonUrl = "https://www.python.org/ftp/python/3.8.10/python-3.8.10-embed-amd64.zip"
 $VSDir = "$FullTargetDir\vapoursynth"
+$VSPipePath = "$VSDir\Lib\site-packages\vapoursynth\vspipe.exe"
 
-# NOTE: guard on BOTH python38.dll AND python38.zip. python38.zip is the Python
-# 3.8 standard library (contains the `encodings` module). It is *.zip-gitignored,
-# so a checked-out deps/windows-x64 tree has python38.dll committed but NOT
-# python38.zip. Guarding on python38.dll alone made CI skip this block and ship a
-# bundle with no stdlib -> "ModuleNotFoundError: No module named 'encodings'".
-if (-not (Test-Path "$VSDir\python38.dll") -or -not (Test-Path "$VSDir\python38.zip")) {
+if (-not (Test-Path $VSPipePath)) {
+    # --- Python embeddable ---
+    $PythonZip = Join-Path $TempDir "python-embed.zip"
+    $PythonUrl = "https://www.python.org/ftp/python/$PythonVersion/python-$PythonVersion-embed-amd64.zip"
     Download-File -Url $PythonUrl -OutFile $PythonZip
+    Expand-Archive -Path $PythonZip -DestinationPath $VSDir -Force
+    Remove-Item $PythonZip -Force
 
-    $PythonTempDir = Join-Path $TempDir "python38-extract"
-    Expand-Archive -Path $PythonZip -DestinationPath $PythonTempDir -Force
-
-    # Copy Python files to VapourSynth directory
-    Copy-Item "$PythonTempDir\python38.dll" $VSDir -Force
-    Copy-Item "$PythonTempDir\python3.dll" $VSDir -Force
-    Copy-Item "$PythonTempDir\python38.zip" $VSDir -Force
-    Copy-Item "$PythonTempDir\*.pyd" $VSDir -Force
-    Copy-Item "$PythonTempDir\libffi-7.dll" $VSDir -Force
-    Copy-Item "$PythonTempDir\libcrypto-1_1.dll" $VSDir -Force
-    Copy-Item "$PythonTempDir\libssl-1_1.dll" $VSDir -Force
-
-    # Create python38._pth file
+    # The embeddable interpreter ignores site-packages unless its ._pth says so.
     @"
-python38.zip
+python$PythonTag.zip
 .
 Lib\site-packages
 import site
-"@ | Set-Content "$VSDir\python38._pth"
+"@ | Set-Content "$VSDir\python$PythonTag._pth"
 
-    Remove-Item $PythonZip -Force
-    Remove-Item $PythonTempDir -Recurse -Force
-    Write-Host "  Python 3.8.10 installed" -ForegroundColor Green
+    # --- VapourSynth wheel ---
+    $VSZip = Join-Path $TempDir "vapoursynth.zip"
+    $VSUrl = "https://github.com/vapoursynth/vapoursynth/releases/download/$VSRelease/VapourSynth64-Portable-$VSRelease.zip"
+    Download-File -Url $VSUrl -OutFile $VSZip
+    $VSTemp = Join-Path $TempDir "vs-portable"
+    Expand-Archive -Path $VSZip -DestinationPath $VSTemp -Force
+    Remove-Item $VSZip -Force
+
+    $Wheel = Get-ChildItem "$VSTemp\wheel" -Filter "*.whl" | Select-Object -First 1
+    if (-not $Wheel) {
+        Write-Host "  ERROR: no wheel found in VapourSynth64-Portable-$VSRelease.zip" -ForegroundColor Red
+        exit 1
+    }
+    Expand-Archive -Path $Wheel.FullName -DestinationPath "$VSDir\Lib\site-packages" -Force
+    Remove-Item $VSTemp -Recurse -Force
+
+    if (-not (Test-Path $VSPipePath)) {
+        Write-Host "  ERROR: vspipe.exe missing after installing $($Wheel.Name)" -ForegroundColor Red
+        exit 1
+    }
+    Write-Host "  VapourSynth $VSRelease installed (Python $PythonVersion)" -ForegroundColor Green
 } else {
-    Write-Host "  Python 3.8.10 already installed" -ForegroundColor Gray
-}
-
-# Install VapourSynth Python 3.8 wheel
-Write-Host "  Installing VapourSynth Python wheel..." -ForegroundColor Gray
-$WheelPath = "$VSDir\wheel\vapoursynth-73-cp38-cp38-win_amd64.whl"
-if (Test-Path $WheelPath) {
-    Expand-Archive -Path $WheelPath -DestinationPath "$VSDir\Lib\site-packages" -Force
-    # Copy .pyd with simple name
-    if (Test-Path "$VSDir\Lib\site-packages\vapoursynth.cp38-win_amd64.pyd") {
-        Copy-Item "$VSDir\Lib\site-packages\vapoursynth.cp38-win_amd64.pyd" "$VSDir\Lib\site-packages\vapoursynth.pyd" -Force
-    }
-
-    # Relocate the wheel's *.data/data/ payload. Expand-Archive mirrors the zip
-    # verbatim, but pip treats a wheel's <name>.data/data/ tree as rooted at the
-    # install *prefix* (here the VS portable dir), not site-packages. For this
-    # wheel that payload is the core vapoursynth.dll, which lands buried at
-    # vapoursynth-73.data\data\Lib\site-packages\vapoursynth.dll. The
-    # vapoursynth.pyd loads vapoursynth.dll at import time and Python 3.8 only
-    # finds it next to the .pyd, so without relocating it VSScript fails with
-    # "Failed to initialize VSScript" for *every* script (preview and pipeline).
-    $WheelDataDir = Get-ChildItem "$VSDir\Lib\site-packages" -Directory -Filter "vapoursynth-*.data" -ErrorAction SilentlyContinue | Select-Object -First 1
-    if ($WheelDataDir) {
-        $DataRoot = Join-Path $WheelDataDir.FullName "data"
-        if (Test-Path $DataRoot) {
-            Get-ChildItem $DataRoot -Recurse -File | ForEach-Object {
-                $Rel = $_.FullName.Substring($DataRoot.Length).TrimStart('\')
-                $Dest = Join-Path $VSDir $Rel
-                New-Item -ItemType Directory -Force -Path (Split-Path $Dest -Parent) | Out-Null
-                Copy-Item $_.FullName $Dest -Force
-                Write-Host "    Relocated wheel data: $Rel" -ForegroundColor Gray
-            }
-        }
-        Remove-Item $WheelDataDir.FullName -Recurse -Force -ErrorAction SilentlyContinue
-    }
-
-    # Sanity check: the core DLL must sit next to the .pyd or VSScript won't init.
-    if (-not (Test-Path "$VSDir\Lib\site-packages\vapoursynth.dll")) {
-        throw "VapourSynth core DLL missing at Lib\site-packages\vapoursynth.dll after wheel install - VSScript will fail to initialize."
-    }
-    Write-Host "  VapourSynth wheel installed" -ForegroundColor Green
+    Write-Host "  VapourSynth $VSRelease already installed" -ForegroundColor Gray
 }
 
 # =============================================================================
@@ -747,7 +717,7 @@ if (-not (Test-Path $WeightsPath)) {
 # only the preview integration test would surface.
 Write-Host ""
 Write-Host "[7.5/8] Verifying VSScript initializes..." -ForegroundColor Yellow
-$VSPipeExe = "$VSDir\VSPipe.exe"
+$VSPipeExe = "$VSDir\Lib\site-packages\vapoursynth\vspipe.exe"
 if (Test-Path $VSPipeExe) {
     $env:PYTHONNOUSERSITE = "1"
     $env:PYTHONHOME = $VSDir
@@ -782,7 +752,7 @@ Write-Host "Dependencies installed to: $FullTargetDir" -ForegroundColor White
 Write-Host ""
 Write-Host "Directory structure:" -ForegroundColor White
 Write-Host "  $FullTargetDir\"
-Write-Host "    vapoursynth\           - VapourSynth + Python 3.8 + vspipe.exe"
+Write-Host "    vapoursynth\           - VapourSynth + Python 3.12 + vspipe.exe"
 Write-Host "      vs-plugins\          - VS plugins (.dll)"
 Write-Host "      Lib\site-packages\   - Python packages (havsfunc, mvsfunc, etc.)"
 Write-Host "    ffmpeg\                - FFmpeg binaries"

--- a/Scripts/download-deps-windows.ps1
+++ b/Scripts/download-deps-windows.ps1
@@ -90,7 +90,7 @@ function Download-File {
 # and matches the macOS and Linux bundles. Pinned rather than probing for the
 # newest patch, so the bundle is reproducible.
 Write-Host ""
-Write-Host "[1/8] Installing Python $PythonVersion embeddable + VapourSynth $VSRelease..." -ForegroundColor Yellow
+Write-Host "[1/7] Installing Python $PythonVersion embeddable + VapourSynth $VSRelease..." -ForegroundColor Yellow
 
 $VSDir = "$FullTargetDir\vapoursynth"
 $VSPipePath = "$VSDir\Lib\site-packages\vapoursynth\vspipe.exe"
@@ -140,7 +140,7 @@ import site
 # 3. FFmpeg
 # =============================================================================
 Write-Host ""
-Write-Host "[3/8] Downloading FFmpeg..." -ForegroundColor Yellow
+Write-Host "[2/7] Downloading FFmpeg..." -ForegroundColor Yellow
 
 $FFmpegZip = Join-Path $TempDir "ffmpeg.zip"
 $FFmpegUrl = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip"
@@ -170,7 +170,7 @@ if (-not (Test-Path "$FullTargetDir\ffmpeg\ffmpeg.exe")) {
 # 4. VapourSynth Plugins (via 7z)
 # =============================================================================
 Write-Host ""
-Write-Host "[4/8] Downloading VapourSynth plugins..." -ForegroundColor Yellow
+Write-Host "[3/7] Downloading VapourSynth plugins..." -ForegroundColor Yellow
 
 # Check for 7-Zip
 $7zPath = "C:\Program Files\7-Zip\7z.exe"
@@ -507,7 +507,7 @@ if (-not (Test-Path $DvdReadPath)) {
 # 5. Python Packages (havsfunc, mvsfunc, adjust)
 # =============================================================================
 Write-Host ""
-Write-Host "[5/8] Downloading Python packages..." -ForegroundColor Yellow
+Write-Host "[4/7] Downloading Python packages..." -ForegroundColor Yellow
 
 $SitePackagesDir = "$FullTargetDir\vapoursynth\Lib\site-packages"
 
@@ -569,7 +569,7 @@ Write-Host "  Python packages installed" -ForegroundColor Green
 # 6. Patch havsfunc for API compatibility
 # =============================================================================
 Write-Host ""
-Write-Host "[6/8] Patching havsfunc for API compatibility..." -ForegroundColor Yellow
+Write-Host "[5/7] Patching havsfunc for API compatibility..." -ForegroundColor Yellow
 
 $HavsfuncPath = "$SitePackagesDir\havsfunc.py"
 if (Test-Path $HavsfuncPath) {
@@ -694,7 +694,7 @@ def _fix_mv_args(args):
 # 7. NNEDI3 Weights (if not already copied with znedi3)
 # =============================================================================
 Write-Host ""
-Write-Host "[7/8] Verifying NNEDI3 weights..." -ForegroundColor Yellow
+Write-Host "[6/7] Verifying NNEDI3 weights..." -ForegroundColor Yellow
 
 $WeightsPath = "$PluginsDir\nnedi3_weights.bin"
 if (-not (Test-Path $WeightsPath)) {
@@ -737,7 +737,7 @@ if (Test-Path $VSPipeExe) {
 # 8. Cleanup
 # =============================================================================
 Write-Host ""
-Write-Host "[8/8] Cleaning up..." -ForegroundColor Yellow
+Write-Host "[7/7] Cleaning up..." -ForegroundColor Yellow
 
 Remove-Item $TempDir -Recurse -Force -ErrorAction SilentlyContinue
 Write-Host "  Cleanup complete" -ForegroundColor Green

--- a/Scripts/download-deps-windows.ps1
+++ b/Scripts/download-deps-windows.ps1
@@ -124,7 +124,13 @@ import site
         Write-Host "  ERROR: no wheel found in VapourSynth64-Portable-$VSRelease.zip" -ForegroundColor Red
         exit 1
     }
-    Expand-Archive -Path $Wheel.FullName -DestinationPath "$VSDir\Lib\site-packages" -Force
+    # A wheel *is* a zip, but Expand-Archive validates the file extension and
+    # rejects .whl outright ("is not a supported archive file format"), so copy
+    # it to a .zip name first rather than unpacking in place.
+    $WheelZip = Join-Path $TempDir "$($Wheel.BaseName).zip"
+    Copy-Item $Wheel.FullName $WheelZip -Force
+    Expand-Archive -Path $WheelZip -DestinationPath "$VSDir\Lib\site-packages" -Force
+    Remove-Item $WheelZip -Force
     Remove-Item $VSTemp -Recurse -Force
 
     if (-not (Test-Path $VSPipePath)) {
@@ -518,7 +524,13 @@ if (-not (Test-Path "$SitePackagesDir\havsfunc.py")) {
     $HavsfuncTar = Join-Path $TempDir "havsfunc.tar.gz"
 
     Download-File -Url $HavsfuncUrl -OutFile $HavsfuncTar
-    & tar -xzf $HavsfuncTar -C $TempDir
+    # Use Windows' own bsdtar by full path. Bare `tar` picks up whatever is first
+    # on PATH, and Git for Windows ships GNU tar, which reads the drive letter in
+    # "C:\..." as a remote host: "tar (child): Cannot connect to C: resolve failed".
+    $SystemTar = Join-Path $env:SystemRoot "System32\tar.exe"
+    if (-not (Test-Path $SystemTar)) { $SystemTar = "tar" }
+    & $SystemTar -xzf $HavsfuncTar -C $TempDir
+    if ($LASTEXITCODE -ne 0) { throw "tar failed to extract $HavsfuncTar (exit $LASTEXITCODE)" }
 
     $HavsfuncPy = Get-ChildItem -Path $TempDir -Recurse -Filter "havsfunc.py" | Select-Object -First 1
     if ($HavsfuncPy) {
@@ -722,7 +734,7 @@ if (Test-Path $VSPipeExe) {
     $env:PYTHONNOUSERSITE = "1"
     $env:PYTHONHOME = $VSDir
     $env:PYTHONPATH = "$VSDir\Lib\site-packages"
-    $env:VAPOURSYNTH_PLUGIN_PATH = $PluginsDir
+    $env:VAPOURSYNTH_EXTRA_PLUGIN_PATH = $PluginsDir
     $env:PATH = "$FullTargetDir\ffmpeg;$VSDir;$env:PATH"
     $VsVersion = & $VSPipeExe --version 2>&1 | Out-String
     if ($LASTEXITCODE -ne 0 -or $VsVersion -notmatch "Core R") {
@@ -732,6 +744,27 @@ if (Test-Path $VSPipeExe) {
 } else {
     throw "VSPipe.exe not found at $VSPipeExe"
 }
+
+# =============================================================================
+# 7.6 Version file
+# =============================================================================
+# Without this the app considers a locally-built deps tree "missing" on startup
+# ("DependencyManager: Version file missing") and downloads the published bundle
+# straight over the top of it. That is destructive whenever the local tree is
+# ahead of the release - building R78 here and then launching the app silently
+# restored the R73 bundle. Stamp the version the app expects so a freshly built
+# tree reads as current. macOS and Linux already write this file.
+Write-Host ""
+Write-Host "[7.6/8] Writing version file..." -ForegroundColor Yellow
+$DepsVersionJson = Join-Path $ProjectRoot "app\assets\deps-version.json"
+$ExpectedVersion = (Get-Content $DepsVersionJson -Raw | ConvertFrom-Json).version
+[ordered]@{
+    version     = $ExpectedVersion
+    installedAt = (Get-Date).ToUniversalTime().ToString("o")
+    platform    = "windows-x64"
+    buildType   = "source"
+} | ConvertTo-Json | Set-Content -Path "$FullTargetDir\version.json" -Encoding utf8
+Write-Host "  version.json written ($ExpectedVersion)" -ForegroundColor Green
 
 # =============================================================================
 # 8. Cleanup

--- a/Scripts/macos-plugin-patches.md
+++ b/Scripts/macos-plugin-patches.md
@@ -225,8 +225,9 @@ The bundle must not depend on Homebrew at runtime, so nothing is copied out of
 - **FFTW** — `libfftw3f.3` and `libfftw3f_threads.3` come pre-built from the
   yuygfgg `support/` pool on arm64, and are **built from source** (3.3.10, float)
   for x86_64 so they meet the macOS 12 deployment target.
-- **FFMS2** — no longer used. Source indexing is **bestsource**
-  (`libbestsource.dylib`).
+- **FFMS2** — no longer used, and neither is **bestsource**, which replaced it.
+  Sources are read as raw frames piped from ffmpeg (`pipe_source.py`), so no
+  source-indexing plugin is bundled at all.
 - The other bundled support libs on x86_64 (zimg, libdvdread, xz, boost) are also
   built from source targeting macOS 12; see the `SRCLIB` section of
   `download-deps-macos.sh` and the x64/#39 notes in `CLAUDE.md`.

--- a/Scripts/package-deps-windows.ps1
+++ b/Scripts/package-deps-windows.ps1
@@ -34,8 +34,19 @@ if (-not (Test-Path $DepsDir)) {
     exit 1
 }
 
-if (-not (Test-Path (Join-Path $DepsDir "vapoursynth\VSPipe.exe"))) {
+# R78 ships Windows as a Python wheel, so vspipe.exe lives inside the installed
+# package next to libvapoursynth.dll rather than at the root of the portable dir.
+if (-not (Test-Path (Join-Path $DepsDir "vapoursynth\Lib\site-packages\vapoursynth\vspipe.exe"))) {
     Write-Host "ERROR: VapourSynth not found in dependencies" -ForegroundColor Red
+    exit 1
+}
+
+# R78 moved every core filter (std, resize, ...) out of libvapoursynth into
+# libvapoursynthfilters.dll. Without it the bundle loads but every job dies at
+# script evaluation with missing namespaces.
+if (-not (Test-Path (Join-Path $DepsDir "vapoursynth\Lib\site-packages\vapoursynth\libvapoursynthfilters.dll"))) {
+    Write-Host "ERROR: libvapoursynthfilters.dll (R78 core filters) missing" -ForegroundColor Red
+    Write-Host "Every job would fail at script evaluation with missing namespaces (std, resize, ...)" -ForegroundColor Red
     exit 1
 }
 
@@ -44,13 +55,13 @@ if (-not (Test-Path (Join-Path $DepsDir "ffmpeg\ffmpeg.exe"))) {
     exit 1
 }
 
-# python38.zip is the Python 3.8 stdlib (contains the `encodings` module). It is
+# python312.zip is the Python 3.12 stdlib (contains the `encodings` module). It is
 # *.zip-gitignored, so it is easy to ship a bundle without it when building from a
 # checked-out deps tree. Without it the app crashes at runtime with:
 #   ModuleNotFoundError: No module named 'encodings'
-$Python38Zip = Join-Path $DepsDir "vapoursynth\python38.zip"
-if (-not (Test-Path $Python38Zip) -or (Get-Item $Python38Zip).Length -lt 1MB) {
-    Write-Host "ERROR: vapoursynth\python38.zip (Python 3.8 stdlib) missing or too small" -ForegroundColor Red
+$PythonStdlibZip = Join-Path $DepsDir "vapoursynth\python312.zip"
+if (-not (Test-Path $PythonStdlibZip) -or (Get-Item $PythonStdlibZip).Length -lt 1MB) {
+    Write-Host "ERROR: vapoursynth\python312.zip (Python 3.12 stdlib) missing or too small" -ForegroundColor Red
     Write-Host "The packaged bundle would crash with: ModuleNotFoundError: No module named 'encodings'" -ForegroundColor Red
     Write-Host "Run '.\Scripts\download-deps-windows.ps1' to fetch it, then re-package" -ForegroundColor Red
     exit 1
@@ -91,6 +102,18 @@ foreach ($dir in $UnnecessaryDirs) {
 
 # Remove __pycache__ directories recursively
 Get-ChildItem -Path "$PackageDir\vapoursynth" -Directory -Recurse -Filter "__pycache__" | Remove-Item -Recurse -Force
+
+# R78's wheel ships debug symbols beside every DLL (libvapoursynth.pdb,
+# libvapoursynthfilters*.pdb, vsscript.pdb) - ~49 MB of them, unused at runtime.
+Get-ChildItem -Path "$PackageDir\vapoursynth" -Recurse -File -Filter "*.pdb" | Remove-Item -Force
+
+# The wheel's SDK payload: C headers and pkg-config files for building plugins
+# against VapourSynth. The R73 layout kept the same thing in an "sdk" directory,
+# already pruned above.
+foreach ($dir in @("include", "pkgconfig")) {
+    $path = Join-Path "$PackageDir\vapoursynth\Lib\site-packages\vapoursynth" $dir
+    if (Test-Path $path) { Remove-Item -Recurse -Force $path }
+}
 
 # Remove development files from site-packages
 $DevDirs = @("cython", "vsscript")

--- a/Scripts/patches/vapoursynth-r78-zimg-api-guard.patch
+++ b/Scripts/patches/vapoursynth-r78-zimg-api-guard.patch
@@ -1,0 +1,54 @@
+VapourSynth R78: guard the zimg chromatic_adaptation field behind an API check
+=============================================================================
+
+Applies to: VapourSynth R78 (github.com/vapoursynth/vapoursynth),
+            src/core/vsresize.cpp
+Affects:    every platform. R78 does not compile against any released zimg.
+Upstream:   already fixed, in commit 37eed3dd ("Add zimg chromatic_adaptation
+            api version check", 2026-08-02). That commit landed AFTER R78 was
+            tagged and is in R79RC1, so this is a straight backport of it, not
+            a change of our own.
+
+Symptom
+-------
+Building R78 against zimg 3.0.6 - the current release, and what Homebrew, the
+distros and VapourSynth's own subprojects/zimg.wrap all provide - fails:
+
+    ../src/core/vsresize.cpp:582:22: error: no member named
+    'chromatic_adaptation' in 'vszimgxx::zfilter_graph_builder_params'
+      582 |   m_params.chromatic_adaptation = propGetScalarDef<int>(...)
+
+R78 added the chromatic_adaptation resize argument and reads the field
+unconditionally, but the field only exists in a zimg newer than 3.0.6
+(ZIMG_API_VERSION 2.5). So the "latest release" of VapourSynth cannot be built
+from source at all with a released zimg.
+
+Why we carry it
+---------------
+The alternatives were worse. Shipping R79RC1 means shipping a prerelease;
+waiting for a zimg release that does not exist yet blocks the upgrade; and
+building zimg from git would pin us to an unreleased revision on all five
+platforms. This is two lines, it is upstream's own fix, and it drops out
+naturally when we move to R79 or later - at which point this patch will stop
+applying and the deps build will hard-fail, which is the intended reminder.
+
+commit 37eed3ddbdb61e92975d9a4b054a488e93fc9a1c
+Author: Fredrik Mellbin <fredrik.mellbin@gmail.com>
+Date:   Sun Aug 2 21:36:03 2026 +0200
+
+    Add zimg chromatic_adaptation api version check
+
+diff --git a/src/core/vsresize.cpp b/src/core/vsresize.cpp
+index 6f3f5405..52ba5ddc 100644
+--- a/src/core/vsresize.cpp
++++ b/src/core/vsresize.cpp
+@@ -579,7 +579,9 @@ class vszimg {
+ 
+             m_params.cpu_type = ZIMG_CPU_AUTO_64B;
+             m_params.allow_approximate_gamma = propGetScalarDef<int>(in, "approximate_gamma", 1, vsapi);
++#if ZIMG_API_VERSION >= ZIMG_MAKE_API_VERSION(2, 5)
+             m_params.chromatic_adaptation = propGetScalarDef<int>(in, "chromatic_adaptation", 1, vsapi);
++#endif
+             m_params.resample_filter = u.filter;
+             m_params.filter_param_a = propGetScalarDef<double>(in, "filter_param_a", m_params.filter_param_a, vsapi);
+             m_params.filter_param_b = propGetScalarDef<double>(in, "filter_param_b", m_params.filter_param_b, vsapi);

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -107,6 +107,25 @@ fi
 echo -e "${GREEN}Prerequisites OK${NC}"
 echo ""
 
+# ---------------------------------------------------------------------------
+# Refuse to ship an app that points at a release-candidate deps bundle.
+# ---------------------------------------------------------------------------
+# Candidate bundles (deps-vX.Y.Z-rcN) exist so a PR touching deps can be tested
+# by CI, the nightly suite and a real app build before anything is published as
+# stable — prereleases are publicly downloadable, drafts are not. They are
+# deliberately disposable, so one escaping into a shipped release is a live
+# hazard: deleting or rebuilding the prerelease later breaks the download for
+# every user who installed that build.
+DEPS_TAG_IN_TREE=$(grep '"releaseTag"' "$PROJECT_ROOT/app/assets/deps-version.json" 2>/dev/null | sed 's/.*: *"\([^"]*\)".*/\1/')
+if [[ "$DEPS_TAG_IN_TREE" == *-rc* ]]; then
+    echo -e "${RED}ERROR: app/assets/deps-version.json points at a release candidate:${NC}"
+    echo -e "${RED}         $DEPS_TAG_IN_TREE${NC}"
+    echo ""
+    echo "Publish the final deps release and repoint deps-version.json at it"
+    echo "before cutting an app release. RC tags must never ship."
+    exit 1
+fi
+
 # Get current versions from GitHub
 echo -e "${YELLOW}Fetching current versions from GitHub...${NC}"
 

--- a/app/assets/deps-version.json
+++ b/app/assets/deps-version.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.7.0",
-  "releaseTag": "deps-v1.7.0",
-  "releaseDate": "2026-08-01",
+  "version": "1.8.0-rc1",
+  "releaseTag": "deps-v1.8.0-rc1",
+  "releaseDate": "2026-08-07",
   "githubRepo": "StuartCameronCode/VapourBox"
 }

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -88,6 +88,9 @@ class AppStartupWrapper extends StatefulWidget {
 class _AppStartupWrapperState extends State<AppStartupWrapper> {
   bool _isReady = false;
   String? _errorMessage;
+  /// Set when the installed deps are newer than this build expects. Shown
+  /// once, after startup, without blocking the app.
+  String? _depsWarning;
 
   @override
   void initState() {
@@ -112,7 +115,24 @@ class _AppStartupWrapperState extends State<AppStartupWrapper> {
         return;
       }
 
-      if (status != DependencyStatus.installed) {
+      // Newer than expected: usable, but never tested against this app build.
+      // Warn once and carry on — downloading would be a silent downgrade, and
+      // the install routine wipes and replaces, so it would also be destructive.
+      if (status == DependencyStatus.newerThanExpected) {
+        final installed =
+            await DependencyManager.instance.getInstalledVersion();
+        final expected = await DependencyManager.instance.getExpectedVersion();
+        if (mounted) {
+          setState(() {
+            _depsWarning =
+                'Installed processing dependencies (${installed?.version}) are '
+                'newer than the version this build of VapourBox was tested with '
+                '(${expected.versionFor(DependencyManager.instance.platformId)}). '
+                'They have been kept, but this combination is unverified — if '
+                'jobs fail unexpectedly, this is worth mentioning in a report.';
+          });
+        }
+      } else if (status != DependencyStatus.installed) {
         // Dependencies need to be downloaded
         if (mounted) {
           final success = await DependencyDownloadDialog.show(context, status);
@@ -148,6 +168,27 @@ class _AppStartupWrapperState extends State<AppStartupWrapper> {
   }
 
   /// Check for updates in the background without blocking startup.
+  Future<void> _showDepsWarningAsync() async {
+    final message = _depsWarning;
+    if (message == null) return;
+    _depsWarning = null; // once only
+    await Future.delayed(const Duration(milliseconds: 500));
+    if (!mounted) return;
+    await showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Unverified dependency version'),
+        content: Text(message),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+  }
+
   Future<void> _checkForUpdatesAsync() async {
     // Wait for the next frame to ensure UI is fully built
     await Future.delayed(const Duration(milliseconds: 500));
@@ -172,6 +213,11 @@ class _AppStartupWrapperState extends State<AppStartupWrapper> {
 
     if (!_isReady) {
       return _buildLoadingScreen();
+    }
+
+    if (_depsWarning != null) {
+      WidgetsBinding.instance
+          .addPostFrameCallback((_) => _showDepsWarningAsync());
     }
 
     return ChangeNotifierProvider(

--- a/app/lib/services/dependency_manager.dart
+++ b/app/lib/services/dependency_manager.dart
@@ -19,8 +19,17 @@ enum DependencyStatus {
   /// Dependencies are not installed
   missing,
 
-  /// Dependencies are installed but wrong version
+  /// Dependencies are installed but older than this app expects
   outdated,
+
+  /// Installed deps are NEWER than the version this app was built against.
+  ///
+  /// Treated as usable, not as something to "fix": replacing them would be a
+  /// silent downgrade, and the newer bundle is the one the user deliberately
+  /// installed (or that a newer app left behind). It has not been tested with
+  /// this app version though, so the user is told once rather than left to
+  /// discover an incompatibility as a job failure.
+  newerThanExpected,
 
   /// Dependencies are installed but SHA256 doesn't match (corrupted)
   corrupted,
@@ -301,8 +310,8 @@ class DependencyManager {
   }
 
   /// Get the version file path within deps directory.
-  Future<File> _getInstalledVersionFile() async {
-    final depsDir = await getDepsDirectory();
+  Future<File> _getInstalledVersionFile({Directory? depsDirOverride}) async {
+    final depsDir = depsDirOverride ?? await getDepsDirectory();
     return File(path.join(depsDir.path, 'version.json'));
   }
 
@@ -355,9 +364,21 @@ class DependencyManager {
         return DependencyStatus.missing;
       }
 
-      // Check version match (per-platform: a platform may pin its own version)
+      // Check version match (per-platform: a platform may pin its own version).
+      // Direction matters. Older than expected is an upgrade; newer is not a
+      // fault at all, and treating it as one downgraded a deliberately newer
+      // bundle back to the released one — destructively, since installing wipes
+      // and replaces.
       final expectedVersion = expected.versionFor(platformId);
       if (installed.version != expectedVersion) {
+        final order = compareVersions(installed.version, expectedVersion);
+        if (order > 0) {
+          print(
+              'DependencyManager: Installed deps ${installed.version} are newer '
+              'than the expected $expectedVersion — keeping them, untested with '
+              'this app version');
+          return DependencyStatus.newerThanExpected;
+        }
         print(
             'DependencyManager: Version mismatch - installed: ${installed.version}, expected: $expectedVersion');
         return DependencyStatus.outdated;
@@ -437,17 +458,50 @@ class DependencyManager {
     }
   }
 
+  /// Compare two dotted version strings numerically.
+  ///
+  /// Returns <0 if [a] is older than [b], 0 if equal, >0 if newer. A plain
+  /// string compare is wrong here — "1.10.0" sorts before "1.9.0" — and these
+  /// values decide whether the app replaces an install. Non-numeric or
+  /// differing-length components degrade to a component-wise best effort rather
+  /// than throwing, because an unparseable version must not crash startup.
+  @visibleForTesting
+  static int compareVersions(String a, String b) {
+    final pa = a.split('.');
+    final pb = b.split('.');
+    for (var i = 0; i < (pa.length > pb.length ? pa.length : pb.length); i++) {
+      final na = i < pa.length ? int.tryParse(pa[i].trim()) ?? 0 : 0;
+      final nb = i < pb.length ? int.tryParse(pb[i].trim()) ?? 0 : 0;
+      if (na != nb) return na < nb ? -1 : 1;
+    }
+    return 0;
+  }
+
   /// Get list of critical files that must exist.
+  ///
+  /// Includes at least one file that exists ONLY in the R78 layout. vspipe,
+  /// the plugin directory and ffmpeg are all present in the pre-R78 bundle
+  /// too, so on their own they cannot tell a current install from a stale one
+  /// carrying a newer version.json — and a stale tree passes every other check
+  /// while failing at job time. libvapoursynthfilters arrived with R78 (it is
+  /// where every core filter now lives) and __init__.py only exists because we
+  /// ship VapourSynth as a Python package, so either one is a reliable marker.
   List<String> _getCriticalFiles() {
     if (Platform.isWindows) {
       return [
         'vapoursynth/Lib/site-packages/vapoursynth/vspipe.exe',
+        'vapoursynth/Lib/site-packages/vapoursynth/libvapoursynthfilters.dll',
         'vapoursynth/vs-plugins',
         'ffmpeg/ffmpeg.exe',
       ];
     } else if (Platform.isMacOS || Platform.isLinux) {
+      final filters = Platform.isMacOS
+          ? 'vapoursynth/libvapoursynthfilters.dylib'
+          : 'vapoursynth/libvapoursynthfilters.so';
       return [
         'vapoursynth/vspipe',
+        filters,
+        'vapoursynth/__init__.py',
         'vapoursynth/plugins',
         'ffmpeg/ffmpeg',
       ];
@@ -504,7 +558,25 @@ class DependencyManager {
 
       final downloadedBytes = await tempFile.length();
 
-      await _extractZip(tempFile);
+      // Build the new install alongside the current one and swap it in, rather
+      // than deleting the current one and extracting over the top. The old path
+      // left the user with nothing between the delete and the last file
+      // written: a crash, a quit, a full disk or a flat battery in that window
+      // meant a mandatory full re-download, and on macOS it unlinked files the
+      // running app may still have had open.
+      //
+      // Costs roughly twice the bundle size on disk while it runs. The staging
+      // and retired directories are siblings of the deps directory, so both
+      // renames stay on one filesystem and the swap is as close to atomic as
+      // the platform allows.
+      final depsDir = await getDepsDirectory();
+      final staging = Directory('${depsDir.path}.new');
+      final retired = Directory('${depsDir.path}.old');
+      for (final d in [staging, retired]) {
+        if (await d.exists()) await d.delete(recursive: true);
+      }
+
+      await _extractZip(tempFile, targetOverride: staging);
 
       // Prove the install is actually usable before declaring success. The
       // quarantine strip above can fail — silently, and it cannot succeed at all
@@ -512,13 +584,39 @@ class DependencyManager {
       // macOS kills on sight. Reporting "Complete" then would hand the user an
       // "ffmpeg exited with signal 9" hours later instead of the real problem
       // now (issue #50).
-      final problem = await executabilityProblem();
+      //
+      // Checked against the staged copy, so a bundle that fails here is thrown
+      // away with the existing install still in place.
+      final problem = await executabilityProblem(depsDirOverride: staging);
       if (problem != null) {
+        await staging.delete(recursive: true).catchError((_) => staging);
         throw Exception(problem);
       }
 
-      // Write version file (per-platform version, so the next check matches)
-      await _writeInstalledVersion(expected.versionFor(platformId));
+      // Write version file (per-platform version, so the next check matches).
+      // Still the last thing written into the tree, so a staged directory that
+      // never gets swapped in can never look complete.
+      await _writeInstalledVersion(expected.versionFor(platformId),
+          depsDirOverride: staging);
+
+      // Swap. If the second rename fails we have already moved the old install
+      // aside, so put it back rather than leaving the user with no deps at all.
+      final hadPrevious = await depsDir.exists();
+      if (hadPrevious) await depsDir.rename(retired.path);
+      try {
+        await staging.rename(depsDir.path);
+      } catch (e) {
+        if (hadPrevious) {
+          await retired.rename(depsDir.path);
+        }
+        rethrow;
+      }
+
+      // Best-effort: the install is already live, so failing to remove the old
+      // copy costs disk space, not correctness.
+      if (hadPrevious) {
+        unawaited(retired.delete(recursive: true).catchError((_) => retired));
+      }
 
       _progressController.add(DownloadProgress(
         bytesReceived: downloadedBytes,
@@ -625,8 +723,8 @@ class DependencyManager {
   }
 
   /// Extract a zip file to the deps directory.
-  Future<void> _extractZip(File zipFile) async {
-    final depsDir = await getDepsDirectory();
+  Future<void> _extractZip(File zipFile, {Directory? targetOverride}) async {
+    final depsDir = targetOverride ?? await getDepsDirectory();
 
     // Create parent directory if needed
     final parentDir = depsDir.parent;
@@ -763,8 +861,10 @@ class DependencyManager {
   }
 
   /// Write the installed version file.
-  Future<void> _writeInstalledVersion(String version) async {
-    final versionFile = await _getInstalledVersionFile();
+  Future<void> _writeInstalledVersion(String version,
+      {Directory? depsDirOverride}) async {
+    final versionFile =
+        await _getInstalledVersionFile(depsDirOverride: depsDirOverride);
     final info = InstalledDepsInfo(
       version: version,
       installedAt: DateTime.now(),

--- a/app/lib/services/dependency_manager.dart
+++ b/app/lib/services/dependency_manager.dart
@@ -441,7 +441,7 @@ class DependencyManager {
   List<String> _getCriticalFiles() {
     if (Platform.isWindows) {
       return [
-        'vapoursynth/VSPipe.exe',
+        'vapoursynth/Lib/site-packages/vapoursynth/vspipe.exe',
         'vapoursynth/vs-plugins',
         'ffmpeg/ffmpeg.exe',
       ];

--- a/app/lib/services/tool_locator.dart
+++ b/app/lib/services/tool_locator.dart
@@ -42,7 +42,7 @@ class ToolLocator {
   String? get workerPath => _workerPath;
 
   /// Environment variables for spawning worker/tool processes.
-  /// Includes PYTHONHOME, PYTHONPATH, VAPOURSYNTH_PLUGIN_PATH, PATH, etc.
+  /// Includes PYTHONHOME, PYTHONPATH, VAPOURSYNTH_EXTRA_PLUGIN_PATH, PATH, etc.
   ///
   /// The temp variables are applied per call rather than baked into the cached
   /// map, so changing the temp directory in Settings takes effect immediately.
@@ -163,7 +163,7 @@ class ToolLocator {
     if (Platform.isWindows) {
       env['PYTHONHOME'] = path.join(_depsDir!, 'vapoursynth');
       env['PYTHONPATH'] = path.join(_depsDir!, 'vapoursynth', 'Lib', 'site-packages');
-      env['VAPOURSYNTH_PLUGIN_PATH'] = path.join(_depsDir!, 'vapoursynth', 'vs-plugins');
+      env['VAPOURSYNTH_EXTRA_PLUGIN_PATH'] = path.join(_depsDir!, 'vapoursynth', 'vs-plugins');
 
       final paths = [
         path.join(_depsDir!, 'vapoursynth'),
@@ -178,7 +178,7 @@ class ToolLocator {
 
       env['PYTHONPATH'] = path.join(_depsDir!, 'python-packages');
       env['PYTHONNOUSERSITE'] = '1';
-      env['VAPOURSYNTH_PLUGIN_PATH'] = path.join(_depsDir!, 'vapoursynth', 'plugins');
+      env['VAPOURSYNTH_EXTRA_PLUGIN_PATH'] = path.join(_depsDir!, 'vapoursynth', 'plugins');
 
       final paths = <String>[];
       if (await bundledPython.exists()) {
@@ -206,7 +206,7 @@ class ToolLocator {
 
       env['PYTHONPATH'] = path.join(_depsDir!, 'python-packages');
       env['PYTHONNOUSERSITE'] = '1';
-      env['VAPOURSYNTH_PLUGIN_PATH'] = path.join(_depsDir!, 'vapoursynth', 'plugins');
+      env['VAPOURSYNTH_EXTRA_PLUGIN_PATH'] = path.join(_depsDir!, 'vapoursynth', 'plugins');
 
       final paths = <String>[];
       if (await bundledPython.exists()) {

--- a/app/lib/services/tool_locator.dart
+++ b/app/lib/services/tool_locator.dart
@@ -176,9 +176,17 @@ class ToolLocator {
         env['PYTHONHOME'] = path.join(_depsDir!, 'python');
       }
 
-      env['PYTHONPATH'] = path.join(_depsDir!, 'python-packages');
+      // The platform dir carries the R78 `vapoursynth` package (libs, vsscript
+      // and the extension module), so it must be importable: vsscript's config
+      // is keyed by the libvsscript path the module reports, and that has to be
+      // the same file vspipe-bin loads.
+      env['PYTHONPATH'] =
+          [_depsDir!, path.join(_depsDir!, 'python-packages')].join(':');
       env['PYTHONNOUSERSITE'] = '1';
-      env['VAPOURSYNTH_EXTRA_PLUGIN_PATH'] = path.join(_depsDir!, 'vapoursynth', 'plugins');
+      // No VAPOURSYNTH_EXTRA_PLUGIN_PATH here: the plugins sit at
+      // <libdir>/plugins, which R78 autoloads. Setting it as well loads every
+      // plugin twice. Windows still needs it — its plugins are in vs-plugins.
+      env['XDG_CONFIG_HOME'] = path.join(_depsDir!, 'config');
 
       final paths = <String>[];
       if (await bundledPython.exists()) {
@@ -204,9 +212,17 @@ class ToolLocator {
         env['PYTHONHOME'] = path.join(_depsDir!, 'python');
       }
 
-      env['PYTHONPATH'] = path.join(_depsDir!, 'python-packages');
+      // The platform dir carries the R78 `vapoursynth` package (libs, vsscript
+      // and the extension module), so it must be importable: vsscript's config
+      // is keyed by the libvsscript path the module reports, and that has to be
+      // the same file vspipe-bin loads.
+      env['PYTHONPATH'] =
+          [_depsDir!, path.join(_depsDir!, 'python-packages')].join(':');
       env['PYTHONNOUSERSITE'] = '1';
-      env['VAPOURSYNTH_EXTRA_PLUGIN_PATH'] = path.join(_depsDir!, 'vapoursynth', 'plugins');
+      // No VAPOURSYNTH_EXTRA_PLUGIN_PATH here: the plugins sit at
+      // <libdir>/plugins, which R78 autoloads. Setting it as well loads every
+      // plugin twice. Windows still needs it — its plugins are in vs-plugins.
+      env['XDG_CONFIG_HOME'] = path.join(_depsDir!, 'config');
 
       final paths = <String>[];
       if (await bundledPython.exists()) {

--- a/app/lib/views/dependency_download_dialog.dart
+++ b/app/lib/views/dependency_download_dialog.dart
@@ -96,6 +96,11 @@ class _DependencyDownloadDialogState extends State<DependencyDownloadDialog> {
       case DependencyStatus.corrupted:
         return 'Some processing components are damaged or incomplete.\n\n'
             'Re-downloading to fix the issue.';
+      case DependencyStatus.newerThanExpected:
+        // main.dart keeps these and warns instead of opening this dialog;
+        // handled so the status can never fall through to the default.
+        return 'The installed processing components are newer than this build '
+            'expects.\n\nThey have been kept.';
       case DependencyStatus.blocked:
         // Re-downloading cannot fix this; main.dart reports the fix instead of
         // opening this dialog. Handled here so the status is never silently

--- a/app/linux/flutter/generated_plugins.cmake
+++ b/app/linux/flutter/generated_plugins.cmake
@@ -10,7 +10,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
-  jni
   rhttp
 )
 

--- a/app/test/deps_version_compare_test.dart
+++ b/app/test/deps_version_compare_test.dart
@@ -1,0 +1,51 @@
+/// The version comparison decides whether the app REPLACES an installed deps
+/// bundle, and installing wipes the existing one. Getting the direction or the
+/// ordering wrong is therefore destructive, not cosmetic:
+///
+///   - a plain string compare puts "1.10.0" before "1.9.0", so a newer bundle
+///     reads as older and gets downgraded;
+///   - treating "newer" as "outdated" downgrades a deliberately newer bundle,
+///     which is how a locally built tree got replaced by the published one.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vapourbox/services/dependency_manager.dart';
+
+void main() {
+  int cmp(String a, String b) => DependencyManager.compareVersions(a, b);
+
+  group('compareVersions', () {
+    test('equal versions compare equal', () {
+      expect(cmp('1.7.0', '1.7.0'), 0);
+    });
+
+    test('orders numerically, not lexically', () {
+      // The case a string compare gets wrong.
+      expect(cmp('1.10.0', '1.9.0'), greaterThan(0));
+      expect(cmp('1.9.0', '1.10.0'), lessThan(0));
+      expect(cmp('2.0.0', '10.0.0'), lessThan(0));
+    });
+
+    test('orders across each component', () {
+      expect(cmp('1.8.0', '1.7.0'), greaterThan(0));
+      expect(cmp('1.7.1', '1.7.0'), greaterThan(0));
+      expect(cmp('2.0.0', '1.99.99'), greaterThan(0));
+    });
+
+    test('missing components count as zero', () {
+      expect(cmp('1.7', '1.7.0'), 0);
+      expect(cmp('1.7.1', '1.7'), greaterThan(0));
+    });
+
+    test('unparseable components degrade instead of throwing', () {
+      // An unreadable version must not crash startup.
+      expect(() => cmp('1.x.0', '1.0.0'), returnsNormally);
+      expect(cmp('', '1.0.0'), lessThan(0));
+    });
+
+    test('the R73 -> R78 upgrade direction is an upgrade, not a downgrade', () {
+      expect(cmp('1.7.0', '1.8.0'), lessThan(0));
+      expect(cmp('1.8.0', '1.7.0'), greaterThan(0));
+    });
+  });
+}

--- a/app/test/support/worker_harness.dart
+++ b/app/test/support/worker_harness.dart
@@ -140,13 +140,14 @@ class WorkerHarness {
       if (bundledPython.existsSync()) {
         env['PYTHONHOME'] = p.join(d, 'python');
       }
-      env['PYTHONPATH'] = p.join(d, 'python-packages');
+      // The platform dir carries the R78 `vapoursynth` package, so it must be
+      // importable — vsscript's config is keyed by the libvsscript path the
+      // module reports, which has to match the one vspipe-bin loads.
+      env['PYTHONPATH'] = [d, p.join(d, 'python-packages')].join(':');
       env['PYTHONNOUSERSITE'] = '1';
-      // R74 replaced VAPOURSYNTH_PLUGIN_PATH with this. Under the old name the
-      // bundled plugins are never autoloaded and every filter fails with
-      // "No attribute with the name <ns> exists".
-      env['VAPOURSYNTH_EXTRA_PLUGIN_PATH'] =
-          p.join(d, 'vapoursynth', 'plugins');
+      // No plugin path variable: the plugins are at <libdir>/plugins, which R78
+      // autoloads. Setting it as well loads every plugin twice.
+      env['XDG_CONFIG_HOME'] = p.join(d, 'config');
 
       final paths = <String>[];
       if (bundledPython.existsSync()) paths.add(p.join(d, 'python', 'bin'));

--- a/app/test/support/worker_harness.dart
+++ b/app/test/support/worker_harness.dart
@@ -594,11 +594,27 @@ class WorkerHarness {
   }
 
   /// Critical files that must exist for a deps dir to count as usable.
+  /// Includes a file that exists only in the R78 layout, so a stale pre-R78
+  /// deps tree is rejected rather than used and failing later at job time.
   static List<String> _criticalFiles() {
     if (Platform.isWindows) {
-      return ['vapoursynth/Lib/site-packages/vapoursynth/vspipe.exe', 'vapoursynth/vs-plugins', 'ffmpeg/ffmpeg.exe'];
+      return [
+        'vapoursynth/Lib/site-packages/vapoursynth/vspipe.exe',
+        'vapoursynth/Lib/site-packages/vapoursynth/libvapoursynthfilters.dll',
+        'vapoursynth/vs-plugins',
+        'ffmpeg/ffmpeg.exe',
+      ];
     }
-    return ['vapoursynth/vspipe', 'vapoursynth/plugins', 'ffmpeg/ffmpeg'];
+    final filters = Platform.isMacOS
+        ? 'vapoursynth/libvapoursynthfilters.dylib'
+        : 'vapoursynth/libvapoursynthfilters.so';
+    return [
+      'vapoursynth/vspipe',
+      filters,
+      'vapoursynth/__init__.py',
+      'vapoursynth/plugins',
+      'ffmpeg/ffmpeg',
+    ];
   }
 
   static bool _depsValid(String dir) {

--- a/app/test/support/worker_harness.dart
+++ b/app/test/support/worker_harness.dart
@@ -590,7 +590,7 @@ class WorkerHarness {
   /// Critical files that must exist for a deps dir to count as usable.
   static List<String> _criticalFiles() {
     if (Platform.isWindows) {
-      return ['vapoursynth/VSPipe.exe', 'vapoursynth/vs-plugins', 'ffmpeg/ffmpeg.exe'];
+      return ['vapoursynth/Lib/site-packages/vapoursynth/vspipe.exe', 'vapoursynth/vs-plugins', 'ffmpeg/ffmpeg.exe'];
     }
     return ['vapoursynth/vspipe', 'vapoursynth/plugins', 'ffmpeg/ffmpeg'];
   }

--- a/app/test/support/worker_harness.dart
+++ b/app/test/support/worker_harness.dart
@@ -131,7 +131,8 @@ class WorkerHarness {
     if (Platform.isWindows) {
       env['PYTHONHOME'] = p.join(d, 'vapoursynth');
       env['PYTHONPATH'] = p.join(d, 'vapoursynth', 'Lib', 'site-packages');
-      env['VAPOURSYNTH_PLUGIN_PATH'] = p.join(d, 'vapoursynth', 'vs-plugins');
+      env['VAPOURSYNTH_EXTRA_PLUGIN_PATH'] =
+          p.join(d, 'vapoursynth', 'vs-plugins');
       final paths = [p.join(d, 'vapoursynth'), p.join(d, 'ffmpeg')];
       env['PATH'] = '${paths.join(';')};${env['PATH'] ?? ''}';
     } else {
@@ -141,7 +142,11 @@ class WorkerHarness {
       }
       env['PYTHONPATH'] = p.join(d, 'python-packages');
       env['PYTHONNOUSERSITE'] = '1';
-      env['VAPOURSYNTH_PLUGIN_PATH'] = p.join(d, 'vapoursynth', 'plugins');
+      // R74 replaced VAPOURSYNTH_PLUGIN_PATH with this. Under the old name the
+      // bundled plugins are never autoloaded and every filter fails with
+      // "No attribute with the name <ns> exists".
+      env['VAPOURSYNTH_EXTRA_PLUGIN_PATH'] =
+          p.join(d, 'vapoursynth', 'plugins');
 
       final paths = <String>[];
       if (bundledPython.existsSync()) paths.add(p.join(d, 'python', 'bin'));

--- a/app/test/vapoursynth_integration_test.dart
+++ b/app/test/vapoursynth_integration_test.dart
@@ -26,7 +26,7 @@ void main() {
     final String ffmpegExe;
     if (Platform.isWindows) {
       depsPlatform = 'windows-x64';
-      vspipeExe = 'VSPipe.exe';
+      vspipeExe = r'Lib\site-packages\vapoursynth\vspipe.exe';
       ffmpegExe = 'ffmpeg.exe';
     } else if (Platform.isMacOS) {
       // Check architecture

--- a/app/test/vapoursynth_integration_test.dart
+++ b/app/test/vapoursynth_integration_test.dart
@@ -5,6 +5,7 @@
 // Run with: flutter test test/vapoursynth_integration_test.dart
 // Note: Requires platform-specific deps to be present with all plugins.
 
+import 'dart:async';
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as path;
@@ -510,7 +511,11 @@ Future<ProcessResult> _runVspipeScript(
       environment = {
         'PYTHONHOME': vsDir,
         'PYTHONPATH': path.join(vsDir, 'Lib', 'site-packages'),
-        'VAPOURSYNTH_PLUGIN_PATH': path.join(vsDir, 'vs-plugins'),
+        // R74 replaced VAPOURSYNTH_PLUGIN_PATH with this; under the old name the
+        // bundled plugins are simply not autoloaded and every filter fails with
+        // "No attribute with the name <ns> exists". Matches
+        // DependencyLocator::build_environment in the worker.
+        'VAPOURSYNTH_EXTRA_PLUGIN_PATH': path.join(vsDir, 'vs-plugins'),
       };
     } else {
       // macOS/Linux - the vspipe wrapper script handles most env setup
@@ -528,18 +533,36 @@ Future<ProcessResult> _runVspipeScript(
         environment: environment,
       );
 
-      // Feed the raw file to stdin
       final rawBytes = await rawFile.readAsBytes();
-      process.stdin.add(rawBytes);
-      await process.stdin.close();
 
-      // Collect output
+      // Start draining BEFORE writing stdin, and never await the write.
+      //
+      // These scripts ask for a single frame, so vspipe reads a fraction of the
+      // raw file and exits; the rest of the write has nowhere to go. Awaiting
+      // `stdin.close()` first then deadlocks — the write blocks on a pipe nobody
+      // is reading, so the drain that would let vspipe finish never starts.
+      //
+      // R73 hid this: it spent ~1.4s evaluating the script, long enough for the
+      // whole 60 KB to land in the OS pipe buffer before vspipe exited. R78
+      // evaluates in ~0.01s and loses the race every time. It was always a race,
+      // not a version difference, so don't "fix" it by reordering back.
       final stdout = StringBuffer();
       final stderr = StringBuffer();
-      await Future.wait([
+      final drained = Future.wait([
         process.stdout.transform(const SystemEncoding().decoder).forEach(stdout.write),
         process.stderr.transform(const SystemEncoding().decoder).forEach(stderr.write),
       ]);
+
+      unawaited(() async {
+        try {
+          process.stdin.add(rawBytes);
+          await process.stdin.close();
+        } catch (_) {
+          // Broken pipe: vspipe got the frames it needed and exited.
+        }
+      }());
+
+      await drained;
       final exitCode = await process.exitCode;
 
       return ProcessResult(process.pid, exitCode, stdout.toString(), stderr.toString());

--- a/worker/src/dependency_locator.rs
+++ b/worker/src/dependency_locator.rs
@@ -507,6 +507,16 @@ impl DependencyLocator {
             // Custom Python packages first (always needed)
             paths.push(platform_dir.join("python-packages").to_string_lossy().to_string());
 
+            // R78 ships VapourSynth as a Python package: libvapoursynth,
+            // libvapoursynthfilters, libvsscript and the extension module all
+            // live in <deps>/vapoursynth/. Putting the platform directory on
+            // the path is what makes `import vapoursynth` resolve to it, and
+            // it is also what lets `vapoursynth config` record the same
+            // libvsscript path that vspipe-bin loads — the config is keyed by
+            // that absolute path, so a mismatch means "Python executable and
+            // library path couldn't be determined".
+            paths.push(platform_dir.to_string_lossy().to_string());
+
             // Add bundled Python site-packages if available
             if let Some(python_home) = self.python_home() {
                 // Python 3.12 from python-build-standalone
@@ -521,6 +531,16 @@ impl DependencyLocator {
         {
             // Linux: same layout as macOS
             paths.push(platform_dir.join("python-packages").to_string_lossy().to_string());
+
+            // R78 ships VapourSynth as a Python package: libvapoursynth,
+            // libvapoursynthfilters, libvsscript and the extension module all
+            // live in <deps>/vapoursynth/. Putting the platform directory on
+            // the path is what makes `import vapoursynth` resolve to it, and
+            // it is also what lets `vapoursynth config` record the same
+            // libvsscript path that vspipe-bin loads — the config is keyed by
+            // that absolute path, so a mismatch means "Python executable and
+            // library path couldn't be determined".
+            paths.push(platform_dir.to_string_lossy().to_string());
 
             if let Some(python_home) = self.python_home() {
                 paths.push(python_home.join("lib").join("python3.12").join("site-packages").to_string_lossy().to_string());
@@ -721,11 +741,32 @@ impl DependencyLocator {
         }
         env.insert("PYTHONPATH".to_string(), self.python_path());
 
-        // Set VapourSynth plugin path
+        // Set VapourSynth plugin path.
+        //
+        // On macOS and Linux the plugins sit at <deps>/vapoursynth/plugins,
+        // which is <libdir>/plugins relative to libvapoursynth, so R78
+        // autoloads them and setting this as well would load every plugin
+        // twice ("Plugin ... already loaded"). Windows keeps it: its plugins
+        // live in vs-plugins, which is not the autoload directory.
+        #[cfg(target_os = "windows")]
         env.insert(
             "VAPOURSYNTH_EXTRA_PLUGIN_PATH".to_string(),
             self.vapoursynth_plugin_path().to_string_lossy().to_string(),
         );
+
+        // vsscript resolves the Python library through a config file keyed by
+        // the libvsscript path, and writes it on first use by shelling out to
+        // a `vapoursynth` executable. Give it a writable location inside the
+        // deps tree and make sure the bundled python/bin (which carries that
+        // shim) is reachable.
+        #[cfg(not(target_os = "windows"))]
+        {
+            env.insert(
+                "XDG_CONFIG_HOME".to_string(),
+                self.platform_dir().join("config").to_string_lossy().to_string(),
+            );
+            let _ = std::fs::create_dir_all(self.platform_dir().join("config"));
+        }
 
         // Set NNEDI3CL weights
         env.insert(

--- a/worker/src/dependency_locator.rs
+++ b/worker/src/dependency_locator.rs
@@ -161,15 +161,23 @@ impl DependencyLocator {
 
         #[cfg(target_os = "windows")]
         {
-            // Windows: VapourSynth portable uses VSPipe.exe
-            let path = vs_dir.join("VSPipe.exe");
+            // R78 ships Windows as a Python wheel, so vspipe.exe lives inside
+            // the installed package next to libvapoursynth.dll rather than at
+            // the root of the portable directory.
+            let path = vs_dir
+                .join("Lib")
+                .join("site-packages")
+                .join("vapoursynth")
+                .join("vspipe.exe");
             if path.exists() {
                 return Ok(path);
             }
-            // Fallback to lowercase
-            let alt = vs_dir.join("vspipe.exe");
-            if alt.exists() {
-                return Ok(alt);
+            // Pre-R78 layouts kept it at the top level.
+            for legacy in ["VSPipe.exe", "vspipe.exe"] {
+                let alt = vs_dir.join(legacy);
+                if alt.exists() {
+                    return Ok(alt);
+                }
             }
         }
 

--- a/worker/src/dependency_locator.rs
+++ b/worker/src/dependency_locator.rs
@@ -700,26 +700,6 @@ impl DependencyLocator {
         }
     }
 
-    /// Write the VapourSynth autoload config to a PER-PROCESS path and return it.
-    ///
-    /// `build_environment` runs on every worker invocation, and `flutter test`
-    /// runs test files concurrently, so writing a shared, fixed-name conf let an
-    /// overlapping vspipe read it mid-truncation — `UserPluginDir` came back
-    /// empty and plugin autoload silently skipped everything (the intermittent
-    /// "No attribute with the name fmtc exists" on the nightly). A per-process
-    /// file (named by PID) is written fully by this process and touched by no
-    /// other, eliminating the race. Verified by reproduction: a shared conf
-    /// failed ~1/120 concurrent runs; per-process was 0/360.
-    fn write_runtime_conf(plugins_dir: &Path) -> Option<PathBuf> {
-        let content = format!(
-            "UserPluginDir={}\nAutoloadUserPluginDir=true\nAutoloadSystemPluginDir=false\n",
-            plugins_dir.to_string_lossy()
-        );
-        let conf_path = env::temp_dir().join(format!("vapourbox-vs-{}.conf", std::process::id()));
-        std::fs::write(&conf_path, content).ok()?;
-        Some(conf_path)
-    }
-
     /// Build environment variables for running vspipe/ffmpeg.
     pub fn build_environment(&self) -> std::collections::HashMap<String, String> {
         let mut env = std::collections::HashMap::new();
@@ -735,7 +715,7 @@ impl DependencyLocator {
 
         // Set VapourSynth plugin path
         env.insert(
-            "VAPOURSYNTH_PLUGIN_PATH".to_string(),
+            "VAPOURSYNTH_EXTRA_PLUGIN_PATH".to_string(),
             self.vapoursynth_plugin_path().to_string_lossy().to_string(),
         );
 
@@ -768,14 +748,16 @@ impl DependencyLocator {
             };
             env.insert("DYLD_LIBRARY_PATH".to_string(), new_dyld);
 
-            // Generate VapourSynth config so vspipe-bin finds bundled plugins
-            // and ignores system plugins (which could conflict).
-            // This replaces the config generation in the vspipe wrapper script,
-            // allowing us to call vspipe-bin directly (so kill() works).
+            // Point vspipe-bin at the bundled plugins. R74 removed the config
+            // file mechanism (UserPluginDir / AutoloadUserPluginDir /
+            // VAPOURSYNTH_CONF_PATH) in favour of this variable, which also
+            // retires the per-process conf file we used to write: there is no
+            // longer a shared file for concurrent runs to race on.
             let plugins_dir = vs_lib_path.join("plugins");
-            if let Some(conf_path) = Self::write_runtime_conf(&plugins_dir) {
-                env.insert("VAPOURSYNTH_CONF_PATH".to_string(), conf_path.to_string_lossy().to_string());
-            }
+            env.insert(
+                "VAPOURSYNTH_EXTRA_PLUGIN_PATH".to_string(),
+                plugins_dir.to_string_lossy().to_string(),
+            );
         }
 
         #[cfg(target_os = "linux")]
@@ -803,11 +785,12 @@ impl DependencyLocator {
             };
             env.insert("LD_LIBRARY_PATH".to_string(), new_ld);
 
-            // Generate VapourSynth config (same as macOS)
+            // Bundled plugin path (same as macOS)
             let plugins_dir = vs_lib_path.join("plugins");
-            if let Some(conf_path) = Self::write_runtime_conf(&plugins_dir) {
-                env.insert("VAPOURSYNTH_CONF_PATH".to_string(), conf_path.to_string_lossy().to_string());
-            }
+            env.insert(
+                "VAPOURSYNTH_EXTRA_PLUGIN_PATH".to_string(),
+                plugins_dir.to_string_lossy().to_string(),
+            );
         }
 
         env

--- a/worker/src/pipeline_executor.rs
+++ b/worker/src/pipeline_executor.rs
@@ -191,7 +191,7 @@ impl PipelineExecutor {
         );
         self.reporter.send_log(
             LogLevel::Debug,
-            &format!("VAPOURSYNTH_PLUGIN_PATH: {:?}", env.get("VAPOURSYNTH_PLUGIN_PATH")),
+            &format!("VAPOURSYNTH_EXTRA_PLUGIN_PATH: {:?}", env.get("VAPOURSYNTH_EXTRA_PLUGIN_PATH")),
         );
 
         // Determine input pixel format for the decoder. Formats pipe_source


### PR DESCRIPTION
Moves the bundled VapourSynth from **R73** (2025-11-23) to **R78**, the current stable release, across all three platforms. It is not a version bump — R74–R78 changed the distribution model, the library set and the plugin-loading mechanism — so most of this is layout and plumbing rather than the tag.

> [!IMPORTANT]
> **CI on this PR cannot pass yet, and that is expected.** `ci-test.yml` downloads the deps bundle pinned in `app/assets/deps-version.json`, which is still `deps-v1.7.0` — an R73 bundle. This branch expects the R78 layout, and the critical-file check now deliberately rejects a pre-R78 tree. A **new deps release must be built and published first**, then `deps-version.json` bumped. `1.7.0` cannot be rebuilt in place: the up-to-date check is a string compare, so re-uploading under the existing tag would leave every installed machine on R73 with no prompt.

## What changed upstream, and what it cost us

| | R73 | R78 |
|---|---|---|
| Core filters | inside `libvapoursynth` | separate **`libvapoursynthfilters`** |
| vsscript | `libvapoursynth-script` | `libvsscript` (unversioned) |
| Python module | `vapoursynth.cpython-312-*.so` | `vapoursynth.abi3.so` |
| `ninja install` target | `<prefix>/bin` + `<prefix>/lib` | `<prefix>/<site-packages>/vapoursynth/` |
| Plugin loading | `VAPOURSYNTH_CONF_PATH` + `UserPluginDir` | `<libdir>/plugins` autoload + `VAPOURSYNTH_EXTRA_PLUGIN_PATH` |
| Windows | portable zip with `VSPipe.exe` + Python 3.8 | **a Python wheel**, Python 3.12+ |

Four findings worth calling out, each verified by building and running rather than read from a changelog:

- **R78 does not compile against any released zimg.** `vsresize.cpp` reads `chromatic_adaptation` unconditionally; that field only exists in a zimg newer than 3.0.6. Upstream fixed it in `37eed3dd` two days *after* tagging R78, so `Scripts/patches/vapoursynth-r78-zimg-api-guard.patch` is that fix backported. It hard-fails if it stops applying, which is the reminder to drop it at R79.
- **`deps/<platform>/vapoursynth/` must *be* the Python package on Unix.** vsscript resolves the Python library through a config keyed by the **absolute path of `libvsscript`**, written by `vapoursynth config` from the *imported* package. Two copies meant the key never matched and every script failed with "Python executable and library path couldn't be determined". This is also why a green Windows run proved nothing here: `_has_implicit_config()` returns true **only** on Windows.
- **Windows ships as a wheel now.** `VapourSynth64-Portable-R78.zip` contains only `wheel\`, `vspipe.bat`, `pip.bat` and docs — no `VSPipe.exe`, no DLLs, no Python. `VSScriptPython38` has zero references in R78 (eight in R73).
- **Plugins must not be autoloaded twice.** With the package layout the plugins sit at `<libdir>/plugins`, which R78 autoloads, so setting `VAPOURSYNTH_EXTRA_PLUGIN_PATH` as well loads all 26 twice. Unix drops it; Windows keeps it (its plugins are in `vs-plugins`).

## Two destructive bugs found on the way

Both pre-existing, both only dangerous once the local tree is *ahead* of the release — exactly what this branch creates.

- **`version.json` was hardcoded `1.0.0`** on macOS/Linux against an expected `1.7.0`, with an exact string compare. A freshly built local tree read as a mismatch and the app downloaded the published bundle over the top of it. On Windows this wiped `ffmpeg/` before it was interrupted.
- **Newer-than-expected deps were treated as `outdated` and replaced** — a silent downgrade, and a destructive one since installing wipes. Now compared numerically (`"1.10.0"` sorts *before* `"1.9.0"` as a string) and kept as `newerThanExpected`, with a one-time non-blocking warning that the combination is untested.

## Install is now staged and swapped

Installing used to delete the live deps directory and extract over the top, leaving the user with nothing if that window was interrupted. It now extracts to `<deps>.new`, verifies it with `executabilityProblem()`, stamps `version.json` there, and swaps via two sibling renames — undoing the first if the second fails. `version.json` is still written last, so it keeps working as the commit marker.

The critical-file list also gained an R78-only marker (`libvapoursynthfilters`, and `vapoursynth/__init__.py` on Unix). `vspipe`, `plugins/` and `ffmpeg` exist in *both* layouts, so without it a stale tree carrying a newer `version.json` passes every check and fails later at job time.

## BestSource removed

Nothing calls it — no `core.bs.` reference anywhere in the templates, worker, app or tests. FFMS2 → BestSource → `pipe_source.py`, and it was left behind, described as "bundled for parity" with platforms that never shipped it. At **16.9 MB** it was four times the next largest plugin, and the **only** consumer of `liblzma` — so its removal also takes the `xz` from-source build, two `install_name_tool` repoint blocks and their codesign steps.

## Verification

| | |
|---|---|
| **macOS arm64** | Real R78 build: all 26 plugins load, `std.Expr`/`resize` correct, QTGMC correct double-rate output. **304 Rust, 266 Flutter, 63 heavy end-to-end encodes** pass. |
| **Windows x64** | Verified on Windows 11 by a separate session — deps build, packaging, suites, and the app launching. Details in commits `4bd994e`/`994b1c7`/`b3ed478`. |
| **rc bundle** | The published `deps-v1.8.0-rc1` macOS arm64 bundle was extracted to a fresh location and run: Core R78, all 25 plugins load, `std.Expr`/`resize` correct, QTGMC correct double-rate output, and no Mach-O reference outside `@loader_path`/`/usr/lib`/`/System`. R73 leftovers (`libvapoursynth-script`, `vapoursynth.conf`, BestSource, `liblzma`, the old `cpython` module) are all absent. |
| **Linux** | **Not verified.** Same scripts as macOS, so low risk, but CI is the test. Note aarch64 needs clang ≥ 17 or GCC ≥ 13 (`_Float16`, `__builtin_roundevenf`) — stock Ubuntu 22.04 cannot build R78 at all. |

## Not done yet

- A **new deps version and release** (blocks CI, see above).
- ~~`build-standalone-app.sh` and `setup-test-bundle.sh` still carry legacy artifact names.~~ Checked: both are relics of the pre-Flutter Swift app (`legacy/iDeinterlace/`). They build against *Homebrew* VapourSynth, not the bundled deps, and nothing in CI or any current build path references them — so they were never part of this migration's surface.
- The staged install needs ~2× bundle size transiently; on Windows a directory rename fails with open handles — it runs at startup before deps are touched, but that path is not yet exercised there.

