### PR TITLE
fix(attribution): correct third-party credit, and assert it stays correct

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,6 +340,11 @@ Adding a filter touches many files. Missing any step causes silent failures (fil
   download URL becomes a red build instead of a silently-incomplete bundle.
 - For local testing, run the download script to populate `deps/` (e.g.
   `deps/windows-x64/vapoursynth/vs-plugins/`, `deps/macos-arm64/vapoursynth/plugins/`).
+- **Credit it**: add an entry to `licenses/NOTICES.txt` and a `_ComponentTile`
+  to `app/lib/views/about_dialog.dart`, then map the binary's filename in
+  `app/test/attribution_test.dart` — that test fails until all three exist.
+  Take the copyright holder and licence from upstream, never from the handle or
+  the repo owner (see "Attribution" below).
 
 ### Regenerating the App Icon
 
@@ -794,7 +799,9 @@ cd app && flutter test                          # everything, incl. heavy (local
 
 Headless Dart-VM tests. Three groups:
 - **Pure unit tests** — `dynamic_parameters`, `filter_schema`,
-  `parameter_converter`, `widget_test`, `scan_type_detection`.
+  `parameter_converter`, `widget_test`, `scan_type_detection`,
+  `attribution` (NOTICES/About-dialog/deps-manifest agreement — see
+  "Attribution" below).
 - **Shell-out tests** — `vapoursynth_integration_test`,
   `schema_converter_integration_test`; need the per-arch `deps/` and (for whisper)
   `addons/`.
@@ -867,6 +874,55 @@ integration tests. Matrix: macOS **arm64** (`macos-15`), macOS **x64**
 - The heavy full-encode integration tests (`@Tags(['heavy'])`) are **not** in this
   gate — they run in `.github/workflows/nightly.yml` (cron + `workflow_dispatch`)
   via `flutter test --tags heavy` on the same 4-platform matrix.
+
+## Attribution — never write a name you have not read upstream
+
+Third-party credit lives in **three** places that must agree:
+`licenses/NOTICES.txt` (shipped in every package), the About dialog
+(`app/lib/views/about_dialog.dart`), and the README's Acknowledgments.
+`app/test/attribution_test.dart` lints the first two against
+`Scripts/deps-expected-plugins.json`, so **adding a plugin without crediting it
+fails the build** — the map in that test has to gain an entry too.
+
+What the test cannot catch, and what actually shipped
+([issue #72](https://github.com/StuartCameronCode/VapourBox/issues/72)):
+
+> **zsmooth was credited to "Adrian Woracz" — a name that does not exist.** The
+> author's GitHub handle is `adworacz`; his LICENSE says **Austin Dworaczyk
+> Wiltshire**. The handle was expanded into a plausible-looking human name
+> instead of being looked up, and it went out in the README, the About dialog
+> and NOTICES simultaneously. The author found it and opened an issue.
+>
+> **Every copyright line must come from the upstream LICENSE file or a source
+> header, fetched at the time of writing.** A GitHub handle is not a name. A
+> repo owner is not necessarily the copyright holder. `gh api repos/<r>` gives
+> the SPDX id, and the LICENSE / first 40 lines of the main source file give the
+> holder — that is a 30-second check per component.
+
+The 2026-08-17 audit that fixed it found the same class of error throughout,
+which is why the whole file was rebuilt from upstream rather than patched:
+
+- **Licences were wrong, not just names.** CTMF is GPL-3.0 (listed as 2.0),
+  DCTFilter is MIT (listed as GPL-2.0), AWarpSharp2 is ISC and RemoveGrain is
+  WTFPL (both listed as GPL-2.0). The bundled FFmpeg is built
+  `--enable-gpl --enable-version3`, so it is **GPL-3.0**, not the LGPL the file
+  claimed.
+- **Year ranges were invented.** "Copyright (c) 2012-2024 …" appeared on
+  components whose upstream states no such range, including projects that
+  assert no copyright at all (havsfunc is Unlicense; FluxSmooth's author
+  explicitly disclaimed copyright).
+- **It credited something not shipped** (ffms2, removed with BestSource) and
+  **omitted about fifteen plugins that are, or shortly will be** — Retinex,
+  bifrost, fluxsmooth, DeScratch, VIVTC, TCanny, TTempSmooth, AddGrain,
+  FFT3DFilter, KNLMeansCL, MiscFilters, TemporalMedian, BM3D, zimg, Zstandard,
+  and the Agner Fog VCL that eight HolyWu plugins compile in. Both directions
+  are now asserted.
+- **`mvsfunc` has no licence at all upstream** — no LICENSE, no header. That is
+  now stated plainly rather than guessed as "Unlicense". Don't "tidy" it into a
+  licence name.
+
+When a project genuinely states nothing, say so and offer to remove it on
+request. An honest "no licence stated" is worth more than a confident guess.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -186,31 +186,43 @@ Stuart Cameron — [stuart-cameron.com](https://stuart-cameron.com)
 
 ## Acknowledgments
 
-- **QTGMC** by Vit — the deinterlacing algorithm
+- **QTGMC** by Vit, originally based on TempGaussMC_beta2 by Didée — the deinterlacing algorithm
 - **VIVTC** by Fredrik Mellbin — VFM field matching and VDecimate for inverse telecine
 - **VapourSynth** by Fredrik Mellbin — video processing framework
-- **havsfunc** by HolyWu — QTGMC VapourSynth port
-- **mvtools** by Manao, Fizick, Pinterf and dubhater — the motion estimation QTGMC is built on
+- **havsfunc**, maintained by HolyWu — the VapourSynth script library QTGMC and many other passes come from
+- **MVTools** — the motion estimation QTGMC is built on; VapourSynth port by dubhater, from the AviSynth plugin by Manao with later work by Fizick, Pinterf and the SVP team
 - **NNEDI3** by Kevin Stone (tritical) — the edge-directed interpolator behind QTGMC, via **znedi3** by sekrit-twc and dubhater's **nnedi3**, whose NEON kernels are what make it fast on Apple Silicon and ARM Linux
-- **akarin** — an LLVM-JIT expression evaluator. VapourSynth's own compiler for filter expressions is x86-only, so on ARM every expression was interpreted once per pixel; this is the single biggest reason Apple Silicon is now several times faster
-- **fmtconv** by Firesledge — format conversion and resampling
-- **zsmooth** by Adrian Woracz — chroma denoising (CCD) and the RemoveGrain family
-- **whisper.cpp** by Georgi Gerganov — speech recognition for subtitle generation
+- **akarin** by Akarin, now maintained by the Jaded Encoding Thaumaturgy project — an LLVM-JIT expression evaluator. VapourSynth's own compiler for filter expressions is x86-only, so on ARM every expression was interpreted once per pixel; this is the single biggest reason Apple Silicon is now several times faster
+- **fmtconv** by Firesledge (Laurent de Soras) — format conversion and resampling
+- **zsmooth** by Austin Dworaczyk Wiltshire — chroma denoising (CCD, originally written by Sergey Stolyarevsky for VirtualDub) and the RemoveGrain family
+- **dubhater** — a long list of VapourSynth ports this app relies on: MVTools, nnedi3, AWarpSharp2, TemporalMedian, FluxSmooth, Bifrost and the `adjust` Tweak port
+- **HolyWu** — the VapourSynth ports of DFTTest, TTempSmooth, TCanny, CTMF, DCTFilter, Deblock, AddGrain, CAS, EEDI3 and NNEDI3CL
+- **mawen1250** — Retinex, BM3D and mvsfunc
+- **whisper.cpp** by the ggml authors — speech recognition for subtitle generation
 - **libdvdread** by VideoLAN — DVD reading and navigation
 - **FFmpeg** project — video encoding
 - **Hybrid** by Selur — inspiration for this project
 
-Full licence texts and the complete list of bundled components are in
-[`licenses/NOTICES.txt`](licenses/NOTICES.txt).
+Full licence texts, copyright holders and the complete list of bundled
+components are in [`licenses/NOTICES.txt`](licenses/NOTICES.txt). If any
+attribution there is wrong or names you incorrectly, please
+[open an issue](https://github.com/StuartCameronCode/VapourBox/issues) — it will
+be fixed.
 
 <details>
 <summary><b>Pre-built binary sources</b></summary>
 
-macOS plugins and binaries sourced from:
+Where a component is taken pre-built rather than compiled from source, it comes
+unmodified from one of these, and thanks are owed to the people who maintain
+them:
 
 - **[yuygfgg/Macos_vapoursynth_plugins](https://github.com/yuygfgg/Macos_vapoursynth_plugins)** — pre-built ARM64 VapourSynth plugins for macOS
 - **[Stefan-Olt/vs-plugin-build](https://github.com/Stefan-Olt/vs-plugin-build)** — cross-platform VapourSynth plugins (arm64 + x86_64; used for `tmedian`)
 - **[evermeet.cx](https://evermeet.cx/ffmpeg/)** — static x86_64 FFmpeg/FFprobe builds for the Intel macOS bundle
+- **[ffmpeg.martin-riedl.de](https://ffmpeg.martin-riedl.de)** — static arm64 FFmpeg/FFprobe builds for the Apple Silicon bundle
+- **[BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds)** — static FFmpeg/FFprobe builds for Windows and Linux
+- **[python-build-standalone](https://github.com/astral-sh/python-build-standalone)** — the relocatable CPython used on macOS and Linux
+- **[Homebrew](https://brew.sh)** — the `whisper-cpp` bottle used for the macOS speech-recognition add-on
 
 The Intel (x64) bundle additionally builds its support libraries (zimg, fftw, libdvdread, boost) from source targeting **macOS 12**, so it runs on Monterey; the Apple Silicon (arm64) bundle is built for the current macOS and targets **macOS 15**.
 

--- a/app/lib/views/about_dialog.dart
+++ b/app/lib/views/about_dialog.dart
@@ -154,17 +154,39 @@ class _AboutDialogState extends State<AboutDialog> {
                   child: ListView(
                     padding: const EdgeInsets.all(8),
                     children: const [
+                      // Every entry here is taken from the upstream project's
+                      // own LICENSE file or source headers, and must match
+                      // licenses/NOTICES.txt. Do not guess a name: if a project
+                      // states no copyright holder, say so or name the project.
                       _ComponentTile(
                         name: 'VapourSynth',
-                        license: 'LGPL 2.1',
+                        license: 'LGPL 2.1+',
                         copyright: 'Fredrik Mellbin',
                         url: 'https://github.com/vapoursynth/vapoursynth',
                       ),
                       _ComponentTile(
+                        name: 'zimg',
+                        license: 'WTFPL',
+                        copyright: 'sekrit-twc',
+                        url: 'https://github.com/sekrit-twc/zimg',
+                      ),
+                      _ComponentTile(
                         name: 'havsfunc',
                         license: 'Unlicense',
-                        copyright: 'HolyWu',
+                        copyright: 'Public domain; maintained by HolyWu',
                         url: 'https://github.com/HomeOfVapourSynthEvolution/havsfunc',
+                      ),
+                      _ComponentTile(
+                        name: 'mvsfunc',
+                        license: 'No licence stated',
+                        copyright: 'mawen1250',
+                        url: 'https://github.com/HomeOfVapourSynthEvolution/mvsfunc',
+                      ),
+                      _ComponentTile(
+                        name: 'adjust',
+                        license: 'WTFPL',
+                        copyright: 'dubhater',
+                        url: 'https://github.com/dubhater/vapoursynth-adjust',
                       ),
                       _ComponentTile(
                         name: 'VIVTC',
@@ -173,9 +195,23 @@ class _AboutDialogState extends State<AboutDialog> {
                         url: 'https://github.com/vapoursynth/vivtc',
                       ),
                       _ComponentTile(
-                        name: 'mvtools',
+                        name: 'MiscFilters',
+                        license: 'LGPL 2.1',
+                        copyright: 'Fredrik Mellbin and contributors',
+                        url: 'https://github.com/vapoursynth/vs-miscfilters-obsolete',
+                      ),
+                      _ComponentTile(
+                        name: 'RemoveGrain / Repair',
+                        license: 'WTFPL',
+                        copyright: 'Laurent de Soras, Fredrik Mellbin; '
+                            'Clense by Victor Efimov (MIT)',
+                        url: 'https://github.com/vapoursynth/vs-removegrain',
+                      ),
+                      _ComponentTile(
+                        name: 'MVTools',
                         license: 'GPL 2.0',
-                        copyright: 'Manao, Fizick, Pinterf, dubhater',
+                        copyright: 'Port by dubhater, from Manao\'s AviSynth '
+                            'plugin with work by Fizick and Pinterf',
                         url: 'https://github.com/dubhater/vapoursynth-mvtools',
                       ),
                       _ComponentTile(
@@ -187,50 +223,28 @@ class _AboutDialogState extends State<AboutDialog> {
                       _ComponentTile(
                         name: 'znedi3',
                         license: 'GPL 2.0',
-                        copyright: 'sekrit-twc',
+                        copyright: 'sekrit-twc, after Kevin Stone, dubhater '
+                            'and Loren Merritt',
                         url: 'https://github.com/sekrit-twc/znedi3',
+                      ),
+                      _ComponentTile(
+                        name: 'NNEDI3CL',
+                        license: 'GPL 2.0',
+                        copyright: 'Kevin Stone (tritical); port by HolyWu',
+                        url: 'https://github.com/HomeOfVapourSynthEvolution/VapourSynth-NNEDI3CL',
                       ),
                       _ComponentTile(
                         name: 'EEDI3',
                         license: 'GPL 2.0',
-                        copyright: 'tritical, HolyWu',
+                        copyright: 'Kevin Stone (tritical); port by HolyWu',
                         url: 'https://github.com/HomeOfVapourSynthEvolution/VapourSynth-EEDI3',
                       ),
                       _ComponentTile(
                         name: 'akarin',
                         license: 'LGPL 3.0',
-                        copyright: 'The akarin plugin authors',
+                        copyright: 'Akarin; maintained by Jaded Encoding '
+                            'Thaumaturgy. Statically links LLVM',
                         url: 'https://github.com/Jaded-Encoding-Thaumaturgy/akarin-vapoursynth-plugin',
-                      ),
-                      _ComponentTile(
-                        name: 'zsmooth',
-                        license: 'MIT',
-                        copyright: 'Adrian Woracz',
-                        url: 'https://github.com/adworacz/zsmooth',
-                      ),
-                      _ComponentTile(
-                        name: 'FFmpeg',
-                        license: 'LGPL 2.1+',
-                        copyright: 'FFmpeg contributors',
-                        url: 'https://github.com/FFmpeg/FFmpeg',
-                      ),
-                      _ComponentTile(
-                        name: 'DFTTest',
-                        license: 'GPL 3.0',
-                        copyright: 'HolyWu',
-                        url: 'https://github.com/HomeOfVapourSynthEvolution/VapourSynth-DFTTest',
-                      ),
-                      _ComponentTile(
-                        name: 'neo-f3kdb',
-                        license: 'GPL 3.0',
-                        copyright: 'HomeOfAviSynthPlusEvolution',
-                        url: 'https://github.com/HomeOfAviSynthPlusEvolution/neo_f3kdb',
-                      ),
-                      _ComponentTile(
-                        name: 'CAS',
-                        license: 'MIT',
-                        copyright: 'HolyWu',
-                        url: 'https://github.com/HomeOfVapourSynthEvolution/VapourSynth-CAS',
                       ),
                       _ComponentTile(
                         name: 'fmtconv',
@@ -239,16 +253,172 @@ class _AboutDialogState extends State<AboutDialog> {
                         url: 'https://gitlab.com/EleonoreMizo/fmtconv',
                       ),
                       _ComponentTile(
+                        name: 'zsmooth',
+                        license: 'MIT',
+                        copyright: 'Austin Dworaczyk Wiltshire; CCD originally '
+                            'by Sergey Stolyarevsky',
+                        url: 'https://github.com/adworacz/zsmooth',
+                      ),
+                      _ComponentTile(
+                        name: 'DFTTest',
+                        license: 'GPL 3.0',
+                        copyright: 'Kevin Stone (tritical); port by HolyWu',
+                        url: 'https://github.com/HomeOfVapourSynthEvolution/VapourSynth-DFTTest',
+                      ),
+                      _ComponentTile(
+                        name: 'FFT3DFilter',
+                        license: 'GPL 2.0',
+                        copyright: 'Fizick (A.G. Balakhnin); port by '
+                            'Yusuke Nakamura',
+                        url: 'https://github.com/myrsloik/VapourSynth-FFT3DFilter',
+                      ),
+                      _ComponentTile(
+                        name: 'TTempSmooth',
+                        license: 'GPL 3.0',
+                        copyright: 'Kevin Stone (tritical); port by HolyWu',
+                        url: 'https://github.com/HomeOfVapourSynthEvolution/VapourSynth-TTempSmooth',
+                      ),
+                      _ComponentTile(
+                        name: 'TCanny',
+                        license: 'GPL 3.0',
+                        copyright: 'Kevin Stone (tritical); port by HolyWu',
+                        url: 'https://github.com/HomeOfVapourSynthEvolution/VapourSynth-TCanny',
+                      ),
+                      _ComponentTile(
+                        name: 'CTMF',
+                        license: 'GPL 3.0',
+                        copyright: 'Simon Perreault; port by HolyWu',
+                        url: 'https://github.com/HomeOfVapourSynthEvolution/VapourSynth-CTMF',
+                      ),
+                      _ComponentTile(
+                        name: 'CAS',
+                        license: 'MIT',
+                        copyright: 'Holy Wu',
+                        url: 'https://github.com/HomeOfVapourSynthEvolution/VapourSynth-CAS',
+                      ),
+                      _ComponentTile(
+                        name: 'DCTFilter',
+                        license: 'MIT',
+                        copyright: 'HolyWu',
+                        url: 'https://github.com/HomeOfVapourSynthEvolution/VapourSynth-DCTFilter',
+                      ),
+                      _ComponentTile(
+                        name: 'Deblock',
+                        license: 'GPL 2.0',
+                        copyright: 'Manao and Fizick; port by HolyWu',
+                        url: 'https://github.com/HomeOfVapourSynthEvolution/VapourSynth-Deblock',
+                      ),
+                      _ComponentTile(
+                        name: 'AddGrain',
+                        license: 'GPL 3.0',
+                        copyright: 'Tom Barry; port by HolyWu',
+                        url: 'https://github.com/HomeOfVapourSynthEvolution/VapourSynth-AddGrain',
+                      ),
+                      _ComponentTile(
+                        name: 'neo_f3kdb',
+                        license: 'GPL 3.0',
+                        copyright: 'Xinyue Lu, from flash3kyuu_deband by '
+                            'SAPikachu',
+                        url: 'https://github.com/HomeOfAviSynthPlusEvolution/neo_f3kdb',
+                      ),
+                      _ComponentTile(
+                        name: 'Retinex',
+                        license: 'GPL 3.0',
+                        copyright: 'mawen1250',
+                        url: 'https://github.com/HomeOfVapourSynthEvolution/VapourSynth-Retinex',
+                      ),
+                      _ComponentTile(
+                        name: 'BM3D',
+                        license: 'MIT',
+                        copyright: 'mawen1250',
+                        url: 'https://github.com/HomeOfVapourSynthEvolution/VapourSynth-BM3D',
+                      ),
+                      _ComponentTile(
+                        name: 'KNLMeansCL',
+                        license: 'GPL 3.0',
+                        copyright: 'Edoardo Brunetti',
+                        url: 'https://github.com/Khanattila/KNLMeansCL',
+                      ),
+                      _ComponentTile(
+                        name: 'DeScratch',
+                        license: 'GPL 2.0',
+                        copyright: 'Fizick (Alexander G. Balakhnin)',
+                        url: 'https://github.com/vapoursynth/descratch',
+                      ),
+                      _ComponentTile(
+                        name: 'AWarpSharp2',
+                        license: 'ISC',
+                        copyright: 'dubhater, after the AviSynth filter by SEt',
+                        url: 'https://github.com/dubhater/vapoursynth-awarpsharp2',
+                      ),
+                      _ComponentTile(
+                        name: 'TemporalMedian',
+                        license: 'ISC',
+                        copyright: 'dubhater',
+                        url: 'https://github.com/dubhater/vapoursynth-temporalmedian',
+                      ),
+                      _ComponentTile(
+                        name: 'FluxSmooth',
+                        license: 'No copyright asserted',
+                        copyright: 'Port by dubhater',
+                        url: 'https://github.com/dubhater/vapoursynth-fluxsmooth',
+                      ),
+                      _ComponentTile(
+                        name: 'Bifrost',
+                        license: 'WTFPL',
+                        copyright: 'Port by dubhater; original by '
+                            'Fredrik Mellbin',
+                        url: 'https://github.com/dubhater/vapoursynth-bifrost',
+                      ),
+                      _ComponentTile(
+                        name: 'Vector Class Library',
+                        license: 'Apache 2.0',
+                        copyright: 'Agner Fog — SIMD code inside several '
+                            'plugins above',
+                        url: 'https://github.com/vectorclass/version2',
+                      ),
+                      _ComponentTile(
+                        name: 'FFmpeg',
+                        license: 'GPL 3.0+',
+                        copyright: 'The FFmpeg developers — built with '
+                            '--enable-gpl --enable-version3',
+                        url: 'https://ffmpeg.org',
+                      ),
+                      _ComponentTile(
                         name: 'whisper.cpp',
                         license: 'MIT',
-                        copyright: 'Georgi Gerganov',
-                        url: 'https://github.com/ggerganov/whisper.cpp',
+                        copyright: 'The ggml authors',
+                        url: 'https://github.com/ggml-org/whisper.cpp',
                       ),
                       _ComponentTile(
                         name: 'libdvdread',
                         license: 'GPL 2.0+',
                         copyright: 'VideoLAN and contributors',
                         url: 'https://code.videolan.org/videolan/libdvdread',
+                      ),
+                      _ComponentTile(
+                        name: 'FFTW',
+                        license: 'GPL 2.0+',
+                        copyright: 'Matteo Frigo and MIT',
+                        url: 'https://www.fftw.org',
+                      ),
+                      _ComponentTile(
+                        name: 'Boost',
+                        license: 'BSL 1.0',
+                        copyright: 'The Boost authors',
+                        url: 'https://www.boost.org',
+                      ),
+                      _ComponentTile(
+                        name: 'zlib',
+                        license: 'zlib',
+                        copyright: 'Jean-loup Gailly and Mark Adler',
+                        url: 'https://zlib.net',
+                      ),
+                      _ComponentTile(
+                        name: 'Zstandard',
+                        license: 'BSD 3-Clause',
+                        copyright: 'Meta Platforms, Inc. and affiliates',
+                        url: 'https://github.com/facebook/zstd',
                       ),
                       _ComponentTile(
                         name: 'Flutter',
@@ -274,8 +444,9 @@ class _AboutDialogState extends State<AboutDialog> {
               // Both are acknowledged in README.md, so neither gets a licence
               // badge here.
               Text(
-                'QTGMC deinterlacing algorithm by Vit. '
-                'Inspired by Hybrid by Selur.',
+                'QTGMC deinterlacing algorithm by Vit, originally based on '
+                'TempGaussMC_beta2 by Didée. Inspired by Hybrid by Selur. '
+                'If any attribution here is wrong, please open an issue.',
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
                       color: Theme.of(context)
                           .colorScheme

--- a/app/macos/Runner/Configs/AppInfo.xcconfig
+++ b/app/macos/Runner/Configs/AppInfo.xcconfig
@@ -11,4 +11,4 @@ PRODUCT_NAME = vapourbox
 PRODUCT_BUNDLE_IDENTIFIER = com.stuartcameron.vapourbox
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2026 Stuart Cameron. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2026 Stuart Cameron. Licensed under the GNU General Public License v3 or later.

--- a/app/test/attribution_test.dart
+++ b/app/test/attribution_test.dart
@@ -1,0 +1,195 @@
+// Attribution lint.
+//
+// Third-party credit lives in three places that drift apart silently:
+//
+//   * licenses/NOTICES.txt        — the legal notice shipped in every package
+//   * app/lib/views/about_dialog.dart — what the user actually reads
+//   * Scripts/deps-expected-plugins.json — what is actually in the bundle
+//
+// Both failure directions have happened. NOTICES kept an entry for ffms2 long
+// after the pipe source replaced it, and it named none of Retinex, bifrost,
+// fluxsmooth, descratch, VIVTC, TCanny or half a dozen other plugins that were
+// added to the bundle. Nothing failed, because nothing checked.
+//
+// So: every plugin binary the bundle is required to contain must be credited,
+// and every component the About dialog names must appear in NOTICES. Adding a
+// plugin now means adding an attribution or the build goes red.
+//
+// Getting a name WRONG is a separate problem this cannot catch — see issue #72,
+// where a plausible-sounding but invented author name shipped. Take every
+// copyright line from the upstream LICENSE or source header, never from memory.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+String _repoRoot() {
+  var dir = Directory.current;
+  while (true) {
+    if (Directory(p.join(dir.path, 'worker')).existsSync() &&
+        Directory(p.join(dir.path, 'app')).existsSync()) {
+      return dir.path;
+    }
+    final parent = dir.parent;
+    if (parent.path == dir.path) {
+      throw StateError('could not locate the repo root from ${Directory.current}');
+    }
+    dir = parent;
+  }
+}
+
+/// Plugin binary stem (lowercased, `lib` prefix and extension stripped) → the
+/// text that must appear in NOTICES.txt for it.
+///
+/// A stem missing from this map fails the test rather than being skipped: a new
+/// plugin has to be credited deliberately, not by whatever its filename happens
+/// to be.
+const _pluginToNotice = <String, String>{
+  'addgrain': 'AddGrain',
+  'akarin': 'akarin',
+  'awarpsharp2': 'AWarpSharp2',
+  'bifrost': 'Bifrost',
+  'bm3d': 'BM3D',
+  'cas': 'CAS',
+  'ctmf': 'CTMF',
+  'dctfilter': 'DCTFilter',
+  'deblock': 'Deblock',
+  'descratch': 'DeScratch',
+  'dfttest': 'DFTTest',
+  'eedi3m': 'EEDI3',
+  'fft3dfilter': 'FFT3DFilter',
+  'fluxsmooth': 'FluxSmooth',
+  'fmtconv': 'fmtconv',
+  'knlmeanscl': 'KNLMeansCL',
+  'miscfilters': 'Miscellaneous Filters',
+  'mvtools': 'MVTools',
+  'neo-f3kdb': 'neo_f3kdb',
+  'nnedi3': 'nnedi3',
+  'nnedi3cl': 'NNEDI3CL',
+  'removegrain': 'RemoveGrain',
+  'removegrainvs': 'RemoveGrain',
+  'retinex': 'Retinex',
+  'tcanny': 'TCanny',
+  'temporalmedian': 'TemporalMedian',
+  'tmedian': 'TemporalMedian',
+  'ttempsmooth': 'TTempSmooth',
+  'vivtc': 'VIVTC',
+  'vsznedi3': 'znedi3',
+  'znedi3': 'znedi3',
+  'zsmooth': 'zsmooth',
+  'zstd': 'Zstandard',
+};
+
+/// Components removed from the bundle whose credit must not linger. Crediting
+/// something that is not shipped is its own kind of inaccuracy.
+const _mustNotAppear = <String>['ffms2', 'BestSource'];
+
+String _stem(String filename) {
+  var s = filename.toLowerCase();
+  final dot = s.lastIndexOf('.');
+  if (dot > 0) s = s.substring(0, dot);
+  if (s.startsWith('lib') && s.length > 3) s = s.substring(3);
+  return s;
+}
+
+void main() {
+  final root = _repoRoot();
+  final notices = File(p.join(root, 'licenses', 'NOTICES.txt')).readAsStringSync();
+
+  group('licenses/NOTICES.txt', () {
+    test('credits every plugin the bundle is required to ship', () {
+      final manifest = jsonDecode(
+        File(p.join(root, 'Scripts', 'deps-expected-plugins.json')).readAsStringSync(),
+      ) as Map<String, dynamic>;
+
+      final uncredited = <String>{};
+      final unmapped = <String>{};
+
+      for (final entry in manifest.entries) {
+        if (entry.key.startsWith('_')) continue; // "_comment"
+        for (final filename in (entry.value as List).cast<String>()) {
+          final stem = _stem(filename);
+          final needle = _pluginToNotice[stem];
+          if (needle == null) {
+            unmapped.add('$filename (stem "$stem")');
+          } else if (!notices.contains(needle)) {
+            uncredited.add('$filename -> expected "$needle" in NOTICES.txt');
+          }
+        }
+      }
+
+      expect(
+        unmapped,
+        isEmpty,
+        reason: 'Plugin(s) with no entry in _pluginToNotice. Add the plugin to '
+            'licenses/NOTICES.txt with its real upstream copyright holder and '
+            'licence, then map it here.',
+      );
+      expect(
+        uncredited,
+        isEmpty,
+        reason: 'Plugin(s) shipped but not credited in licenses/NOTICES.txt.',
+      );
+    });
+
+    test('does not credit components that are no longer shipped', () {
+      for (final gone in _mustNotAppear) {
+        expect(
+          notices.contains(gone),
+          isFalse,
+          reason: '"$gone" is not bundled any more; remove its NOTICES entry.',
+        );
+      }
+    });
+
+    test('points at the licence texts it references', () {
+      final referenced = RegExp(r'Licence text:\s*([A-Za-z0-9.\-]+\.txt)')
+          .allMatches(notices)
+          .map((m) => m.group(1)!)
+          .toSet();
+
+      for (final file in referenced) {
+        expect(
+          File(p.join(root, 'licenses', file)).existsSync(),
+          isTrue,
+          reason: 'NOTICES.txt references licenses/$file, which does not exist.',
+        );
+      }
+      expect(referenced, isNotEmpty);
+    });
+  });
+
+  group('About dialog', () {
+    test('names only components that NOTICES.txt also credits', () {
+      final source = File(
+        p.join(root, 'app', 'lib', 'views', 'about_dialog.dart'),
+      ).readAsStringSync();
+
+      final names = RegExp(r"name:\s*'([^']+)'")
+          .allMatches(source)
+          .map((m) => m.group(1)!)
+          .toSet();
+
+      expect(
+        names.length,
+        greaterThan(20),
+        reason: 'the component list looks truncated — did the parse break?',
+      );
+
+      // "RemoveGrain / Repair" and the like carry a qualifier the notice file
+      // spells differently, so match on the first word of the component name.
+      final missing = names.where((n) {
+        final head = n.split(RegExp(r'[ /]')).first;
+        return !notices.contains(head);
+      }).toList();
+
+      expect(
+        missing,
+        isEmpty,
+        reason: 'About dialog names component(s) absent from NOTICES.txt.',
+      );
+    });
+  });
+}

--- a/app/windows/runner/Runner.rc
+++ b/app/windows/runner/Runner.rc
@@ -89,13 +89,13 @@ BEGIN
     BEGIN
         BLOCK "040904e4"
         BEGIN
-            VALUE "CompanyName", "com.vapourbox" "\0"
-            VALUE "FileDescription", "vapourbox" "\0"
+            VALUE "CompanyName", "Stuart Cameron" "\0"
+            VALUE "FileDescription", "VapourBox" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "vapourbox" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2026 com.vapourbox. All rights reserved." "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2026 Stuart Cameron. Licensed under the GNU General Public License v3 or later." "\0"
             VALUE "OriginalFilename", "vapourbox.exe" "\0"
-            VALUE "ProductName", "vapourbox" "\0"
+            VALUE "ProductName", "VapourBox" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/licenses/NOTICES.txt
+++ b/licenses/NOTICES.txt
@@ -1,184 +1,544 @@
-VapourBox - Third Party Licenses
-===================================
+VapourBox — Third-Party Notices
+===============================
 
-This application includes the following third-party components:
+VapourBox itself is Copyright (c) Stuart Cameron and is distributed under the
+GNU General Public License, version 3 or (at your option) any later version.
+See LICENSE in the repository root.
 
+This file lists the third-party components distributed with VapourBox — either
+inside the application bundle or inside the separately downloaded dependency
+bundle (deps-vX.Y.Z). Every copyright line and licence below was taken from the
+upstream project's own LICENSE file or source headers. Where a project makes no
+copyright or licence statement, that is said so plainly rather than guessed at.
 
-VapourSynth (LGPL 2.1)
-----------------------
-Copyright (c) 2012-2024 Fredrik Mellbin
-https://github.com/vapoursynth/vapoursynth
-License: See LGPL-2.1.txt
+Some components are shipped only on some platforms; that is noted per entry.
 
-
-havsfunc (Unlicense)
---------------------
-Copyright (c) 2012-2024 HolyWu
-https://github.com/HomeOfVapourSynthEvolution/havsfunc
-License: Public Domain (Unlicense)
-
-
-mvsfunc (Unlicense)
--------------------
-Copyright (c) 2014-2024 mawen1250
-https://github.com/HomeOfVapourSynthEvolution/mvsfunc
-License: Public Domain (Unlicense)
+Full texts of the longer licences are in the accompanying files:
+  GPL-2.0.txt, GPL-3.0.txt, LGPL-2.1.txt, LGPL-3.0.txt,
+  Apache-2.0-LLVM-Exception.txt
+The short permissive licences (MIT, ISC, BSD 3-Clause, WTFPL, Boost, zlib,
+Unlicense) are reproduced in full in the appendix at the end of this file.
 
 
-mvtools (GPL 2.0)
------------------
-Copyright (c) 2005-2024 Manao, Fizick, Pinterf, dubhater
-https://github.com/dubhater/vapoursynth-mvtools
-License: See GPL-2.0.txt
+-------------------------------------------------------------------------------
+1. Framework and runtime
+-------------------------------------------------------------------------------
+
+VapourSynth — LGPL-2.1-or-later
+  Copyright (c) 2012-2024 Fredrik Mellbin
+  https://github.com/vapoursynth/vapoursynth
+  Licence text: LGPL-2.1.txt
+  The video processing framework. Includes libvapoursynth, libvapoursynthfilters
+  (the core std/resize/text filters), libvsscript and the vspipe tool.
+
+zimg — WTFPL
+  Copyright (c) sekrit-twc
+  https://github.com/sekrit-twc/zimg
+  The scaling/format-conversion library behind core.resize. Bundled because
+  VapourSynth links it.
+
+Python (CPython) — Python Software Foundation License 2.0
+  Copyright (c) 2001-2024 Python Software Foundation
+  https://github.com/python/cpython
+  Licence: https://docs.python.org/3/license.html
+  macOS/Linux use a python-build-standalone distribution
+  (https://github.com/astral-sh/python-build-standalone, MPL-2.0 for its own
+  build scripts); Windows uses the official embeddable package.
+
+Flutter — BSD 3-Clause
+  Copyright (c) 2014 The Flutter Authors
+  https://github.com/flutter/flutter
+  The UI toolkit the application is written in.
 
 
-nnedi3 (GPL 2.0)
-----------------
-Copyright (c) 2010-2011 Kevin Stone (tritical); VapourSynth port by dubhater
-https://github.com/dubhater/vapoursynth-nnedi3
-License: See GPL-2.0.txt
-The same neural network as znedi3, from the same nnedi3_weights.bin, but with
-NEON kernels. Shipped on the ARM bundles only, where znedi3's x86-only SIMD
-leaves it running scalar; havsfunc and both templates select it at runtime on
-arm64/aarch64. x86 bundles ship znedi3 alone.
+-------------------------------------------------------------------------------
+2. VapourSynth Python modules
+-------------------------------------------------------------------------------
 
-znedi3 (GPL 2.0)
-----------------
-Copyright (c) 2018-2024 sekrit-twc
-https://github.com/sekrit-twc/znedi3
-License: See GPL-2.0.txt
+havsfunc — Unlicense (public domain dedication)
+  https://github.com/HomeOfVapourSynthEvolution/havsfunc
+  Maintained by HolyWu. The upstream LICENSE is the Unlicense, which dedicates
+  the work to the public domain, so no copyright is asserted.
+  Contains QTGMC 3.33 by Vit (2012), itself originally based on
+  TempGaussMC_beta2 by Didee, along with daa, santiag, Stab, SMDegrain,
+  DeHalo_alpha, FineDehalo, LSFmod, STPresso, SmoothLevels, LUTDeCrawl,
+  LUTDeRainbow, Deblock_QED, EdgeCleaner, YAHR and others used by VapourBox.
+  VapourBox applies small compatibility patches to this file at dependency
+  build time; they are listed in Scripts/download-deps-*.
 
+mvsfunc — no licence stated upstream
+  Copyright (c) mawen1250 <mawen1250@gmail.com>
+  https://github.com/HomeOfVapourSynthEvolution/mvsfunc
+  The upstream repository contains no LICENSE file and no licence header in the
+  source. It is bundled unmodified because havsfunc imports it. If the author
+  would prefer it not be redistributed, please open an issue and it will be
+  removed.
 
-EEDI3 (GPL 2.0)
----------------
-Copyright (c) 2010-2024 tritical, HolyWu
-https://github.com/HomeOfVapourSynthEvolution/VapourSynth-EEDI3
-License: See GPL-2.0.txt
-
-
-fmtconv (WTFPL)
----------------
-Copyright (c) 2012-2024 Firesledge (Laurent de Soras)
-https://github.com/EleonoreMizo/fmtconv
-License: WTFPL (Do What The F*ck You Want To Public License)
-
-
-FFmpeg (LGPL 2.1+)
-------------------
-Copyright (c) 2000-2024 FFmpeg contributors
-https://github.com/FFmpeg/FFmpeg
-License: See LGPL-2.1.txt (or GPL depending on build configuration)
+adjust — WTFPL
+  Copyright (c) dubhater
+  https://github.com/dubhater/vapoursynth-adjust
+  A port of the AviSynth Tweak filter; provides adjust.Tweak, used by the
+  Colour Correction pass.
 
 
-ffms2 (MIT)
+-------------------------------------------------------------------------------
+3. VapourSynth plugins
+-------------------------------------------------------------------------------
+
+MVTools — GPL-2.0
+  VapourSynth port by dubhater
+  https://github.com/dubhater/vapoursynth-mvtools
+  A port of the AviSynth plugin by Manao, with later work by Fizick
+  (Alexander G. Balakhnin), Pinterf and the SVP team. Licence text: GPL-2.0.txt
+  Motion estimation and compensation — the engine QTGMC and SMDegrain use.
+
+nnedi3 — GPL-2.0
+  Copyright (C) 2010-2011 Kevin Stone (tritical); VapourSynth port by dubhater
+  https://github.com/dubhater/vapoursynth-nnedi3
+  Licence text: GPL-2.0.txt
+  Shipped on the ARM bundles only (macos-arm64, linux-arm64), where its NEON
+  kernels are several times faster than znedi3's scalar fallback. The x86
+  bundles ship znedi3 alone.
+
+znedi3 — GPL-2.0
+  Copyright (c) sekrit-twc; based on work by dubhater, Kevin Stone and
+  Loren Merritt (per the project's AUTHORS.txt)
+  https://github.com/sekrit-twc/znedi3
+  Licence text: GPL-2.0.txt
+  The same neural network as nnedi3, from the same nnedi3_weights.bin.
+
+NNEDI3CL — GPL-2.0
+  Copyright (C) 2010-2011 Kevin Stone (tritical); OpenCL VapourSynth port by
+  HolyWu
+  https://github.com/HomeOfVapourSynthEvolution/VapourSynth-NNEDI3CL
+  Licence text: GPL-2.0.txt
+
+EEDI3 (eedi3m) — GPL-2.0
+  Copyright (C) tritical (Kevin Stone); VapourSynth port by HolyWu
+  https://github.com/HomeOfVapourSynthEvolution/VapourSynth-EEDI3
+  Licence text: GPL-2.0.txt
+
+VIVTC — LGPL-2.1
+  Copyright (c) 2012-2020 Fredrik Mellbin
+  https://github.com/vapoursynth/vivtc
+  Licence text: LGPL-2.1.txt
+  VFM field matching and VDecimate, used by the inverse-telecine pass.
+
+MiscFilters (Miscellaneous Filters, namespace misc) — LGPL-2.1
+  Copyright (c) 2016 Fredrik Mellbin & other contributors
+  https://github.com/vapoursynth/vs-miscfilters-obsolete
+  Licence text: LGPL-2.1.txt
+
+RemoveGrain / Repair (rgvs) — WTFPL, with one MIT component
+  AvsFilterRemoveGrain/Repair16 by Laurent de Soras (2012), modified for
+  VapourSynth by Fredrik Mellbin (2013) — WTFPL
+  Clense: Copyright (c) 2013 Victor Efimov — MIT
+  https://github.com/vapoursynth/vs-removegrain
+
+fmtconv — WTFPL
+  Copyright (c) Firesledge (Laurent de Soras)
+  https://gitlab.com/EleonoreMizo/fmtconv
+  Format conversion and resampling. Pinned to r31 on every platform.
+  VapourBox applies Scripts/patches/fmtconv-r31-arm-int-scaler.patch on the
+  from-source (macOS/Linux) builds, fixing a bug in the non-SIMD integer scaler
+  that produced black output on ARM. The patch header carries the analysis.
+
+akarin — LGPL-3.0
+  Copyright (c) Akarin <i@akarin.info>; now maintained by the Jaded Encoding
+  Thaumaturgy project
+  https://github.com/Jaded-Encoding-Thaumaturgy/akarin-vapoursynth-plugin
+  Licence text: LGPL-3.0.txt
+  Provides core.akarin.Expr, an LLVM-JIT implementation of std.Expr.
+  VapourSynth's own Expr JIT is x86-only, so on ARM every expression is
+  otherwise interpreted once per pixel; akarin supplies the JIT those platforms
+  lack. Distributed as an unmodified binary taken from the project's published
+  wheel, and dynamically linked — the LGPL relinking right is satisfied by
+  replacing that binary in deps/<platform>/vapoursynth/plugins/.
+  Not shipped on macOS x64.
+
+LLVM — Apache-2.0 WITH LLVM-exception
+  Copyright (c) the LLVM Project contributors
+  https://llvm.org
+  Licence text: Apache-2.0-LLVM-Exception.txt
+  LLVM 22.1.2 is statically linked into the akarin plugin above, which is where
+  its JIT comes from. Listed here because that binary carries LLVM code.
+
+zsmooth — MIT
+  Copyright (c) 2024 Austin Dworaczyk Wiltshire
+  https://github.com/adworacz/zsmooth
+  Provides core.zsmooth.CCD (used by the Chroma Denoise pass), Cnr4, and a set
+  of RemoveGrain/TemporalMedian/FluxSmooth-family filters.
+  CCD — Camcorder Colour Denoiser — was originally written by Sergey
+  Stolyarevsky for VirtualDub.
+
+DFTTest — GPL-3.0
+  Copyright (C) 2007-2010 Kevin Stone (tritical); VapourSynth port by HolyWu
+  https://github.com/HomeOfVapourSynthEvolution/VapourSynth-DFTTest
+  Licence text: GPL-3.0.txt
+
+FFT3DFilter — GPL-2.0
+  Copyright (C) 2004-2006 A.G. Balakhnin aka Fizick
+  Copyright (C) 2015 Yusuke Nakamura (VapourSynth port)
+  https://github.com/myrsloik/VapourSynth-FFT3DFilter
+  Licence text: GPL-2.0.txt
+
+TTempSmooth — GPL-3.0
+  Copyright (C) 2004-2005 Kevin Stone (tritical); VapourSynth port by HolyWu
+  https://github.com/HomeOfVapourSynthEvolution/VapourSynth-TTempSmooth
+  Licence text: GPL-3.0.txt
+
+TCanny — GPL-3.0
+  Copyright (C) 2009 Kevin Stone (tritical); VapourSynth port by HolyWu
+  https://github.com/HomeOfVapourSynthEvolution/VapourSynth-TCanny
+  Licence text: GPL-3.0.txt
+
+CTMF — GPL-3.0
+  Copyright (C) 2006 Simon Perreault (constant-time median filtering);
+  VapourSynth port by HolyWu
+  https://github.com/HomeOfVapourSynthEvolution/VapourSynth-CTMF
+  Licence text: GPL-3.0.txt
+
+CAS — MIT
+  Copyright (c) 2020 Holy Wu
+  https://github.com/HomeOfVapourSynthEvolution/VapourSynth-CAS
+  Contrast Adaptive Sharpening, after AMD's FidelityFX CAS.
+
+DCTFilter — MIT
+  Copyright (c) 2017 HolyWu
+  https://github.com/HomeOfVapourSynthEvolution/VapourSynth-DCTFilter
+
+Deblock — GPL-2.0
+  Copyright (c) 2004 Manao (originally a function in MVTools 0.9.6.2)
+  Copyright (c) 2006 Alexander Balakhnin aka Fizick (separate plugin)
+  VapourSynth port by HolyWu
+  https://github.com/HomeOfVapourSynthEvolution/VapourSynth-Deblock
+  Licence text: GPL-2.0.txt
+
+AddGrain — GPL-3.0
+  Copyright (c) 2002 Tom Barry; VapourSynth port by HolyWu
+  https://github.com/HomeOfVapourSynthEvolution/VapourSynth-AddGrain
+  Licence text: GPL-3.0.txt
+
+neo_f3kdb — GPL-3.0
+  Copyright (c) 2020 Xinyue Lu; forked from flash3kyuu_deband by SAPikachu
+  https://github.com/HomeOfAviSynthPlusEvolution/neo_f3kdb
+  Licence text: GPL-3.0.txt
+
+Retinex — GPL-3.0
+  Copyright (C) 2014 mawen1250
+  https://github.com/HomeOfVapourSynthEvolution/VapourSynth-Retinex
+  Licence text: GPL-3.0.txt
+
+BM3D — MIT
+  Copyright (c) 2015-2016 mawen1250
+  https://github.com/HomeOfVapourSynthEvolution/VapourSynth-BM3D
+  Shipped on macOS arm64 only.
+
+KNLMeansCL — GPL-3.0
+  Copyright (C) 2015-2020 Edoardo Brunetti
+  https://github.com/Khanattila/KNLMeansCL
+  Licence text: GPL-3.0.txt
+  OpenCL non-local-means denoising; degrades gracefully where no OpenCL device
+  is available.
+
+DeScratch — GPL-2.0
+  Copyright (C) 2003-2016 Alexander G. Balakhnin aka Fizick
+  https://github.com/vapoursynth/descratch
+  Licence text: GPL-2.0.txt
+
+AWarpSharp2 — ISC
+  Copyright (c) dubhater; a rewrite of the AviSynth filter (re)written by SEt
+  https://github.com/dubhater/vapoursynth-awarpsharp2
+
+TemporalMedian — ISC
+  Copyright (c) dubhater
+  https://github.com/dubhater/vapoursynth-temporalmedian
+
+FluxSmooth — no copyright asserted
+  VapourSynth port by dubhater
+  https://github.com/dubhater/vapoursynth-fluxsmooth
+  The project's readme records the original FluxSmooth author's statement:
+  "There is no copyright on this code, and there are no conditions on its
+  distribution or use. Do with it what you will."
+
+Bifrost — WTFPL
+  VapourSynth port by dubhater; the original AviSynth derainbowing filter was
+  created by Fredrik Mellbin
+  https://github.com/dubhater/vapoursynth-bifrost
+
+Vector Class Library (VCL) — Apache-2.0
+  Copyright (c) Agner Fog
+  https://github.com/vectorclass/version2
+  Not a plugin of its own: several of the HolyWu-maintained plugins above
+  (CAS, CTMF, DCTFilter, Deblock, DFTTest, TCanny, TTempSmooth, AddGrain)
+  compile it in for their SIMD paths.
+
+
+-------------------------------------------------------------------------------
+4. Media tools and libraries
+-------------------------------------------------------------------------------
+
+FFmpeg — GPL-3.0-or-later (as built)
+  Copyright (c) 2000-2026 the FFmpeg developers
+  https://ffmpeg.org — https://github.com/FFmpeg/FFmpeg
+  Licence text: GPL-3.0.txt
+  FFmpeg is LGPL-2.1-or-later at its core, but the builds VapourBox bundles are
+  configured with --enable-gpl --enable-version3, which makes the resulting
+  binaries GPL-3.0-or-later. They also link, among others, x264 and x265
+  (GPL-2.0-or-later), which is why the GPL configuration is used.
+  Binaries are taken pre-built and unmodified from:
+    - macOS arm64: https://ffmpeg.martin-riedl.de
+    - macOS x64:   https://evermeet.cx/ffmpeg/
+    - Windows and Linux: https://github.com/BtbN/FFmpeg-Builds
+  Run `ffmpeg -version` on the bundled binary for its exact configuration, and
+  see https://ffmpeg.org/legal.html for source availability.
+
+whisper.cpp — MIT
+  Copyright (c) 2023-2026 The ggml authors (project started by Georgi Gerganov)
+  https://github.com/ggml-org/whisper.cpp
+  Speech recognition for subtitle generation. Distributed as a separately
+  downloaded optional add-on, not inside the application bundle: on macOS from
+  the Homebrew whisper-cpp bottle, on Windows from the project's own release,
+  on Linux from an unmodified build published on this repository's releases.
+
+libdvdread — GPL-2.0-or-later
+  Copyright (c) VideoLAN and contributors
+  https://code.videolan.org/videolan/libdvdread
+  Licence text: GPL-2.0.txt
+  DVD reading and navigation. libdvdcss is deliberately NOT bundled; users who
+  need it install it themselves.
+
+FFTW — GPL-2.0-or-later
+  Copyright (c) Matteo Frigo and the Massachusetts Institute of Technology
+  https://www.fftw.org
+  Licence text: GPL-2.0.txt
+  Required by MVTools and FFT3DFilter.
+
+Boost — Boost Software License 1.0
+  Copyright (c) the Boost authors
+  https://www.boost.org
+  Linked by the OpenCL plugins.
+
+zlib — zlib licence
+  Copyright (c) 1995-2024 Jean-loup Gailly and Mark Adler
+  https://zlib.net
+
+Zstandard — BSD 3-Clause (dual-licensed BSD/GPL-2.0 upstream)
+  Copyright (c) Meta Platforms, Inc. and affiliates
+  https://github.com/facebook/zstd
+  Shipped on Windows and Linux only, as a private dependency of the akarin
+  plugin's published wheel.
+
+
+-------------------------------------------------------------------------------
+5. Build tooling present in the dependency bundle
+-------------------------------------------------------------------------------
+
+The bundled Python installation carries the tools its own build needed. They
+are not used at runtime but are distributed, so they are listed here.
+
+Cython — Apache-2.0        https://github.com/cython/cython
+Meson  — Apache-2.0        https://github.com/mesonbuild/meson
+pip    — MIT               https://github.com/pypa/pip
+
+
+-------------------------------------------------------------------------------
+6. Application packages
+-------------------------------------------------------------------------------
+
+The Flutter application and the Rust worker link a number of permissively
+licensed packages from pub.dev and crates.io (BSD 3-Clause, MIT or Apache-2.0).
+The authoritative lists, with versions, are app/pubspec.yaml (resolved in
+app/pubspec.lock) and worker/Cargo.toml (resolved in worker/Cargo.lock).
+Direct dependencies:
+
+  Dart/Flutter: provider, file_picker, desktop_drop, path_provider, path,
+                json_annotation, uuid, shared_preferences, url_launcher,
+                window_manager, rhttp, archive, crypto, package_info_plus
+  Rust:         serde, serde_json, uuid, clap, thiserror, anyhow, ctrlc, which,
+                chrono, libloading
+
+
+-------------------------------------------------------------------------------
+7. Acknowledged, but not distributed
+-------------------------------------------------------------------------------
+
+Hybrid by Selur (https://www.selur.de) is the inspiration for this project.
+No Hybrid code is used or distributed.
+
+
+===============================================================================
+Appendix — full text of the short permissive licences
+===============================================================================
+
+MIT License
 -----------
-Copyright (c) 2007-2024 FFMS contributors
-https://github.com/FFMS/ffms2
-License: MIT License
+(Applies to zsmooth, CAS, DCTFilter, BM3D, whisper.cpp, pip and the Clense
+filter in vs-removegrain, each under the copyright notice given in its entry
+above.)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 
-DFTTest (GPL 3.0)
------------------
-Copyright (c) 2015-2024 HolyWu
-https://github.com/HomeOfVapourSynthEvolution/VapourSynth-DFTTest
-License: See GPL-3.0.txt
+ISC License
+-----------
+(Applies to AWarpSharp2 and TemporalMedian.)
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
 
 
-neo-f3kdb (GPL 3.0)
--------------------
-Copyright (c) 2019-2024 HomeOfAviSynthPlusEvolution
-https://github.com/HomeOfAviSynthPlusEvolution/neo_f3kdb
-License: See GPL-3.0.txt
+DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE, Version 2
+------------------------------------------------------
+(Applies to fmtconv, zimg, RemoveGrain/Repair, Bifrost and adjust.)
+
+            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+                    Version 2, December 2004
+
+ Copyright (C) 2004 Sam Hocevar <sam@hocevar.net>
+
+ Everyone is permitted to copy and distribute verbatim or modified
+ copies of this license document, and changing it is allowed as long
+ as the name is changed.
+
+            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. You just DO WHAT THE FUCK YOU WANT TO.
 
 
-CAS - Contrast Adaptive Sharpening (MIT)
-----------------------------------------
-Copyright (c) 2019-2024 HolyWu
-https://github.com/HomeOfVapourSynthEvolution/VapourSynth-CAS
-License: MIT License
-
-
-DCTFilter (GPL 2.0)
--------------------
-Copyright (c) 2014-2024 HolyWu
-https://github.com/HomeOfVapourSynthEvolution/VapourSynth-DCTFilter
-License: See GPL-2.0.txt
-
-
-Deblock (GPL 2.0)
------------------
-Copyright (c) 2004-2024 Manao, Fizick
-https://github.com/HomeOfVapourSynthEvolution/VapourSynth-Deblock
-License: See GPL-2.0.txt
-
-
-AWarpSharp2 (GPL 2.0)
----------------------
-Copyright (c) 2015-2024 dubhater
-https://github.com/dubhater/vapoursynth-awarpsharp2
-License: See GPL-2.0.txt
-
-
-RemoveGrain (GPL 2.0)
----------------------
-https://github.com/vapoursynth/vs-removegrain
-License: See GPL-2.0.txt
-
-
-CTMF (GPL 2.0)
---------------
-Copyright (c) 2014-2024 HolyWu
-https://github.com/HomeOfVapourSynthEvolution/VapourSynth-CTMF
-License: See GPL-2.0.txt
-
-
-zsmooth (MIT)
--------------
-Copyright (c) 2025 Adrian Woracz
-https://github.com/adworacz/zsmooth
-License: MIT License
-Provides core.zsmooth.CCD (Camcorder Colour Denoise), used by the Chroma
-Denoise pass. CCD itself originates as a VirtualDub filter by Sergey
-Stolyarevsky.
-
-
-akarin (LGPL-3.0)
------------------
-Copyright (c) the akarin plugin authors
-https://github.com/Jaded-Encoding-Thaumaturgy/akarin-vapoursynth-plugin
-License: See LGPL-3.0.txt
-Provides core.akarin.Expr, an LLVM-JIT implementation of std.Expr. VapourSynth's
-own Expr JIT is x86-only, so on ARM every expression is otherwise interpreted
-once per pixel; akarin supplies the JIT those platforms lack. Distributed as an
-unmodified binary taken from the project's published wheel, and dynamically
-linked -- the LGPL relinking right is satisfied by replacing that binary in
-deps/<platform>/vapoursynth/plugins/. Not shipped on macOS x64.
-
-LLVM (Apache-2.0 WITH LLVM-exception)
--------------------------------------
-Copyright (c) the LLVM Project contributors
-https://llvm.org
-License: See Apache-2.0-LLVM-Exception.txt
-LLVM 22.1.2 is statically linked into the akarin plugin above, which is where
-its JIT comes from. Included here because that binary carries LLVM code.
-
-
-Flutter (BSD 3-Clause)
-----------------------
-Copyright (c) 2014-2024 The Flutter Authors
-https://github.com/flutter/flutter
-License: BSD 3-Clause License
-
-
-Python (PSF License)
+BSD 3-Clause License
 --------------------
-Copyright (c) 2001-2024 Python Software Foundation
-https://github.com/python/cpython
-License: Python Software Foundation License
+(Applies to Flutter and Zstandard, under the copyright notices given above.)
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-===================================
-Full license texts are provided in the accompanying license files:
-- GPL-2.0.txt
-- GPL-3.0.txt
-- LGPL-2.1.txt
+Boost Software License 1.0
+--------------------------
+
+Permission is hereby granted, free of charge, to any person or organization
+obtaining a copy of the software and accompanying documentation covered by
+this license (the "Software") to use, reproduce, display, distribute, execute,
+and transmit the Software, and to prepare derivative works of the Software,
+and to permit third-parties to whom the Software is furnished to do so, all
+subject to the following:
+
+The copyright notices in the Software and this entire statement, including the
+above license grant, this restriction and the following disclaimer, must be
+included in all copies of the Software, in whole or in part, and all
+derivative works of the Software, unless such copies or derivative works are
+solely in the form of machine-executable object code generated by a source
+language processor.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
+SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE FOR
+ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+zlib License
+------------
+
+This software is provided 'as-is', without any express or implied warranty. In
+no event will the authors be held liable for any damages arising from the use
+of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it freely,
+subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim
+   that you wrote the original software. If you use this software in a
+   product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+
+
+The Unlicense
+-------------
+(Applies to havsfunc.)
+
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute
+this software, either in source code form or as a compiled binary, for any
+purpose, commercial or non-commercial, and by any means.
+
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and successors. We intend this dedication to be an
+overt act of relinquishment in perpetuity of all present and future rights to
+this software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org/>
+
+
+===============================================================================
+Corrections
+===============================================================================
+
+If any attribution here is wrong, incomplete, or names you incorrectly, please
+open an issue at https://github.com/StuartCameronCode/VapourBox/issues and it
+will be fixed.


### PR DESCRIPTION
Fixes #72.

## The reported bug

zsmooth was credited to **"Adrian Woracz"** in the README, the About dialog and `NOTICES.txt`. That name does not exist — the author's handle is `adworacz` and [his LICENSE](https://github.com/adworacz/zsmooth/blob/master/LICENSE) says **Austin Dworaczyk Wiltshire**. The handle had been expanded into a plausible-sounding human name instead of being looked up, and he found it himself.

## Why this touches so much

Rather than patch the one line, I re-derived every attribution from upstream `LICENSE` files and source headers. The same class of error was throughout:

**Wrong licences**
| Component | Listed as | Actually |
|---|---|---|
| CTMF | GPL-2.0 | GPL-3.0 |
| DCTFilter | GPL-2.0 | MIT |
| AWarpSharp2 | GPL-2.0 | ISC |
| RemoveGrain / Repair | GPL-2.0 | WTFPL (+ MIT for Clense) |
| FFmpeg | LGPL-2.1+ | **GPL-3.0** — every bundled build is `--enable-gpl --enable-version3` |

**Invented year ranges** — `Copyright (c) 2012-2024 …` appeared on components whose upstream asserts no such range, including two that assert no copyright at all (havsfunc is Unlicense; FluxSmooth's original author explicitly disclaimed copyright).

**Credited something not shipped** — ffms2, removed alongside BestSource.

**Omitted ~15 plugins that are shipped** — Retinex, bifrost, fluxsmooth, DeScratch, VIVTC, TCanny, TTempSmooth, AddGrain, FFT3DFilter, KNLMeansCL, MiscFilters, TemporalMedian, BM3D, zimg, Zstandard, plus the Agner Fog Vector Class Library that eight HolyWu plugins compile in.

**`mvsfunc` has no licence upstream at all** — no LICENSE file, no header, nothing in `setup.py`. It was listed as "Unlicense". It now says so plainly, with an offer to remove it on request.

## What else changed

- **Original authors named** where a port obscured them: Kevin Stone behind DFTTest/TCanny/TTempSmooth/NNEDI3CL, Simon Perreault behind CTMF, Tom Barry behind AddGrain, Fizick behind FFT3DFilter/DeScratch/Deblock, SEt behind AWarpSharp2, Sergey Stolyarevsky behind CCD, Didée behind QTGMC's ancestor TempGaussMC_beta2, SAPikachu behind neo_f3kdb, Akarin behind akarin.
- **Permissive licence texts reproduced in full** — MIT, ISC, WTFPL, BSD-3-Clause, Boost, zlib and the Unlicense all require the notice be included with the distribution, and none of them were.
- **In-app strings** — the Windows exe's file properties gave `CompanyName` and `LegalCopyright` as literally `"com.vapourbox"`; both platforms claimed "All rights reserved" on a GPL-3 app.
- **Pre-built binary sources** in the README now also credit martin-riedl, BtbN, python-build-standalone and the Homebrew bottle, not just the three macOS ones.

## Guard

`app/test/attribution_test.dart` (4 tests, runs in the push gate — no deps needed) keeps the three places in step:

- every plugin in `deps-expected-plugins.json` is credited in `NOTICES.txt`
- every About-dialog component appears in `NOTICES.txt`
- no removed component (ffms2, BestSource) lingers
- every `Licence text:` file referenced actually exists in `licenses/`

It caught two of my own inconsistencies while I was writing it. What it *cannot* catch is a name that is simply wrong, so `CLAUDE.md` records the rule: a handle is not a name, a repo owner is not the copyright holder, and every copyright line comes from upstream at the time of writing.

## Note on scope

bifrost, fluxsmooth and Retinex arrive with deps 1.9.0 on `feat/advanced-mode-and-filter-curation`, not on `main` — they are credited here anyway, since both branches land before the next release. Nothing else here depends on that branch; the two touch no common files apart from `README.md` and `CLAUDE.md`, which merged cleanly in testing.

## Verification

- `flutter test test/attribution_test.dart` — 4/4
- `flutter analyze` — no new issues
- Every copyright line traced to an upstream `LICENSE` or source header (`gh api repos/<r>` for the SPDX id, raw file fetch for the holder)